### PR TITLE
Makes web service "host" setting global

### DIFF
--- a/app/models/uw_web_services/nonstandard_web_service_result.rb
+++ b/app/models/uw_web_services/nonstandard_web_service_result.rb
@@ -178,20 +178,13 @@ class NonstandardWebServiceResult
   
     # Attaches our cert, key, and CA file based on the config options in web_services.yml.
     def ssl_options
-      return {} unless check_cert_paths!
-      @ssl_options ||= {
-        :cert         => OpenSSL::X509::Certificate.new(File.open(File.join(ENV['SHARED_CONFIG_ROOT'] || "#{Rails.root}/config", "certs", config_options[:cert]))),
-        :key          => OpenSSL::PKey::RSA.new(File.open(File.join(ENV['SHARED_CONFIG_ROOT'] || "#{Rails.root}/config", "certs", config_options[:key]))),
-        :ca_file      => File.join(ENV['SHARED_CONFIG_ROOT'] || "#{Rails.root}/config", "certs", config_options[:ca_file]),
-        :verify_mode  => OpenSSL::SSL::VERIFY_PEER
-      }
+      UwWebResource.ssl_options
     end
   
     # All configuration options are stored in Rails.root/config/web_services.yml. This allows us to use different
     # hosts, certs, etc. in different Rails environments.
     def config_options
-      config_file_path = File.join(ENV['SHARED_CONFIG_ROOT'] || "#{Rails.root}/config", "web_services.yml")
-      @config_options ||= YAML::load(ERB.new((IO.read(config_file_path))).result)[(Rails.env)][Apartment::Tenant.current].symbolize_keys
+      UwWebResource.config_options
     end
   
     def headers

--- a/config/web_services.yml
+++ b/config/web_services.yml
@@ -1,14 +1,16 @@
 development:
-  uwdp:
-    host: ucswseval1.cac.washington.edu
-    cert: uwdp.crt
-    key: uwdp.key
-    ca_file: uwca.pem
-    act_as_user: dreamsis
+  host: ucswseval1.cac.washington.edu
+  tenant_options:
+    uwdp:
+      cert: uwdp.crt
+      key: uwdp.key
+      ca_file: uwca.pem
+      act_as_user: dreamsis
 production:
-  uwdp:
-    host: ws.admin.washington.edu
-    cert: uwdp.crt
-    key: uwdp.key
-    ca_file: uwca.pem
-    act_as_user: dreamsis
+  host: ws.admin.washington.edu
+  tenant_options:
+    uwdp:
+      cert: uwdp.crt
+      key: uwdp.key
+      ca_file: uwca.pem
+      act_as_user: dreamsis


### PR DESCRIPTION
Previously this setting was tenant-specific, but that prevented
self.site from working when the tenant changed. Now the host setting is
global, but the cert info have been moved into a “tenant_options” node
in web_services.yml.
