### PR TITLE
Improve NSC processing to use sidekiq

### DIFF
--- a/app/assets/stylesheets/dreamsis.css
+++ b/app/assets/stylesheets/dreamsis.css
@@ -1720,6 +1720,20 @@ abbr[title]:hover {
 /*  padding: 0.5em;*/
 }
 
+p.warning {
+  background: rgba(255,206,0,0.25) url("../images/icons/silk/error.png") 0.5em 0.5em no-repeat;  
+  border-radius: 5px;
+  border: 1px solid rgba(255,206,0,0.3);
+  padding: 0.5em;
+  padding-left: 32px;
+  color: #3f3f3f;
+  margin: 1em 0;
+}
+
+p.warning strong {
+  font-weight: bolder;
+}
+
 .stats .warning {
   background: inherit;
 }
@@ -2704,7 +2718,7 @@ form.formtastic li#participant_zip_input input, form.formtastic li#parent_zip_in
 
 
 form.formtastic fieldset p:first-child {
-	margin: -10px -2px 2em -7px;
+	margin: -22px -2px 2em -7px;
 	padding: 7px;
 	background: rgba(0,0,0,0.03);
 }
@@ -4659,6 +4673,16 @@ code.criteria pre {
 	display: inline;
 	white-space: normal;
 	font-family: inherit;
+}
+
+code.log-file {
+  display: block;
+  max-height: 30em;
+  overflow: scroll;
+  white-space: pre-wrap;
+  box-shadow: inset 0 0 10px rgba(0,0,0,0.1);
+  border-radius: 10px;
+  padding: 1em;
 }
 
 .hoverable .show_on_hover {

--- a/app/controllers/clearinghouse_requests_controller.rb
+++ b/app/controllers/clearinghouse_requests_controller.rb
@@ -35,11 +35,20 @@ class ClearinghouseRequestsController < ApplicationController
   def file
     @clearinghouse_request = ClearinghouseRequest.find(params[:id])
     if params[:file] == 'submission'
-      file_path = @clearinghouse_request.nsc.generate_file!
-    elsif !params[:file].to_i.zero?
-      file_path = @clearinghouse_request.files[params[:file].to_i-1]
+      file_url = @clearinghouse_request.file_url(@clearinghouse_request.nsc.send_filename)
+    elsif !params[:file].blank?
+      file_url = @clearinghouse_request.file_url(params[:file])
     end
-    send_file file_path, :disposition => 'attachment'
+    redirect_to file_url
+  end
+  
+  def refresh_status
+    @clearinghouse_request = ClearinghouseRequest.find(params[:id])
+    @output = File.read(@clearinghouse_request.logger.instance_variable_get(:@logdev).filename)
+    
+    respond_to do |format|
+      format.js
+    end
   end
   
   def submit
@@ -55,7 +64,7 @@ class ClearinghouseRequestsController < ApplicationController
   def retrieve
     @clearinghouse_request = ClearinghouseRequest.find(params[:id])
     if @clearinghouse_request.retrieve!
-      flash[:notice] = "The file was successfully retrieved from NSC and processed."
+      flash[:notice] = "The file was successfully retrieved from NSC and accepted for processing."
     else
       flash[:error] = "There was a problem retrieving the file. Please try again or upload the results file manually."
     end
@@ -102,8 +111,10 @@ class ClearinghouseRequestsController < ApplicationController
     File.open(path, 'w') do |file|
       file.write(file_io.read)
     end
-    if @clearinghouse_request.process_detail_file(path)
-      flash[:notice] = "Retrieved file processed successfully."
+  	Rollbar.warning "Sidekiq not running" unless Report.sidekiq_ready?
+    
+    if ClearinghouseRequestWorker.perform_async(@clearinghouse_request.id, path)
+      flash[:notice] = "Retrieved file accepted for processing."
     else
       flash[:error] = "The file could not be processed."
     end

--- a/app/controllers/clearinghouse_requests_controller.rb
+++ b/app/controllers/clearinghouse_requests_controller.rb
@@ -71,6 +71,10 @@ class ClearinghouseRequestsController < ApplicationController
     redirect_to(@clearinghouse_request)
   end
   
+  def results
+    @clearinghouse_request = ClearinghouseRequest.find(params[:id])
+  end
+  
   def create
     @clearinghouse_request = ClearinghouseRequest.new(params[:clearinghouse_request])
     @clearinghouse_request.customer_id = Customer.current_customer.id

--- a/app/models/clearinghouse_request.rb
+++ b/app/models/clearinghouse_request.rb
@@ -146,6 +146,7 @@ class ClearinghouseRequest < ActiveRecord::Base
           participant = Participant.find(participant_id) rescue nil
           if participant
             logger.info { "  -> MATCHED to participant id #{participant.id}" }
+            participant.update_attribute(:clearinghouse_record_found, true)
           else
             logger.info { "  -> PARTICIPANT NOT FOUND" }
             next

--- a/app/models/college_degree.rb
+++ b/app/models/college_degree.rb
@@ -5,6 +5,8 @@ class CollegeDegree < Degree
   belongs_to :clearinghouse_request
   belongs_to :institution
 
+  scope :from_clearinghouse_request, lambda { |clearinghouse_request_id| where(:clearinghouse_request_id => clearinghouse_request_id) }
+  
   # Returns a printable String of the names of the majors for this record.
   def majors_list
     [major_1, major_2, major_3, major_4].select{|m| !m.blank? }.collect(&:titleize).join(", ")

--- a/app/models/college_enrollment.rb
+++ b/app/models/college_enrollment.rb
@@ -6,6 +6,8 @@ class CollegeEnrollment < Enrollment
   belongs_to :grade_level, :foreign_key => :abbreviation, :primary_key => :class_level
   belongs_to :institution
 
+  scope :from_clearinghouse_request, lambda { |clearinghouse_request_id| where(:clearinghouse_request_id => clearinghouse_request_id) }
+
   CLASS_LEVEL_NAMES = {
     "C" => "Certificate (Undergraduate)",
     "A" => "Associate's",

--- a/app/models/enrollment.rb
+++ b/app/models/enrollment.rb
@@ -3,7 +3,7 @@ class Enrollment < ActiveRecord::Base
   validates_presence_of :participant_id  
   belongs_to :participant, :touch => true
   
-  validates_uniqueness_of :institution_id, :scope => [:participant_id, :began_on, :ended_on, :enrollment_status, :class_level]
+  validates_uniqueness_of :institution_id, :scope => [:participant_id, :began_on, :ended_on, :enrollment_status, :class_level], :message => "an identical enrollment already exists with those attributes for the participant"
   
   after_save :update_filter_cache
   after_destroy :update_filter_cache

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -48,6 +48,11 @@ class Institution < ActiveRecord::Base
       super(*args)
     end
   end
+  
+  # Strips out hyphens from OPEID before searching.
+  def self.find_by_opeid(opeid)
+    super(opeid.to_s.gsub("-", ""))
+  end
 
 	def to_title
 		title

--- a/app/uploaders/clearinghouse_request_uploader.rb
+++ b/app/uploaders/clearinghouse_request_uploader.rb
@@ -1,0 +1,18 @@
+class ClearinghouseRequestUploader < CarrierWave::Uploader::Base
+
+  storage :fog
+
+  # def initialize(request_id)
+  #   @request_id = request_id
+  #   super
+  # end
+
+  def store_dir
+    "uploads/nsc/#{@model}"
+  end
+
+  def cache_dir
+    "#{Rails.root}/tmp/" + store_dir
+  end
+
+end

--- a/app/views/clearinghouse_requests/_clearinghouse_request.html.erb
+++ b/app/views/clearinghouse_requests/_clearinghouse_request.html.erb
@@ -1,5 +1,5 @@
 <tr id="clearinghouse_request_<%= clearinghouse_request.id.to_s %> <%= clearinghouse_request.status %>">
-	<td class="name"><%= link_to clearinghouse_request.id.to_s, clearinghouse_request %></td>
+	<td class="name"><%= link_to "##{clearinghouse_request.id.to_s}", clearinghouse_request %></td>
 	<td><%= clearinghouse_request.created_at.to_s(:short_date) %></td>
 	<td><%= content_tag :span, clearinghouse_request.status, :class => "#{clearinghouse_request.status} status tag" %></td>
 	<td class="centered number"><%= clearinghouse_request.participant_ids.size %></td>

--- a/app/views/clearinghouse_requests/_fields.html.erb
+++ b/app/views/clearinghouse_requests/_fields.html.erb
@@ -1,6 +1,12 @@
 <%= f.inputs :name => "Choose participants to submit" do -%>
 	<p>Choose the cohorts that should be submitted to the National Student Clearinghouse.</p>
 	
+	<p class="warning">
+		<strong>Tip:</strong>
+		Only include cohorts that have graduated high school. The list below includes all cohorts 
+		but the National Student Clearinghouse will only return results for students who have graduated high school.
+	</p>
+	
 	<%- for cohort in Participant.cohorts -%>
 		<li class="boolean optional" id="cohort_<%= cohort %>_input">
 			<label for="cohort_<%= cohort %>">

--- a/app/views/clearinghouse_requests/refresh_status.js.erb
+++ b/app/views/clearinghouse_requests/refresh_status.js.erb
@@ -1,0 +1,18 @@
+<%- if @clearinghouse_request.submitted? -%>
+  $('#processing_log_container')
+    .addClass('log-file')
+    .html("<%=j @output %>")
+    .scrollTop($('#processing_log_container')[0].scrollHeight)
+  
+  <%- unless @clearinghouse_request.retrieved? -%>
+    setTimeout(function() { 
+      $.ajax("<%=j refresh_status_clearinghouse_request_path(@clearinghouse_request, :current_status => @clearinghouse_request.status) %>", 
+        { dataType: 'script' }) 
+      }, 3000)
+  <%- end -%>
+    
+<%- end %>
+
+<%- if params[:current_status] != 'retrieved' && @clearinghouse_request.retrieved? -%>
+  window.location = "<%=j clearinghouse_request_path(@clearinghouse_request) %>"
+<%- end %>

--- a/app/views/clearinghouse_requests/results.html.erb
+++ b/app/views/clearinghouse_requests/results.html.erb
@@ -1,0 +1,33 @@
+<h3 class="pre-title"><%= link_to "Request ##{@clearinghouse_request.id.to_s}", @clearinghouse_request %></h3>
+<h1>Results</h1>
+
+<table>
+	<thead>
+		<th>Participant</th>
+		<th class="centered">Record Found</th>
+		<th class="centered">Enrollments</th>
+		<th class="centered">Degrees</th>
+	</thead>
+	
+	<tbody>
+	<%- for participant in @clearinghouse_request.participants -%>
+		<tr>
+			<td class="name"><%= link_to participant.fullname, participant %></td>
+			<td class="centered">
+				<%= content_tag :span, participant.clearinghouse_record_found?, :class => "icon pass" if participant.clearinghouse_record_found? %>
+			</td>
+			<td class="centered">
+				<%= p = participant.college_enrollments.from_clearinghouse_request(@clearinghouse_request.id); p.size unless p.empty? %>
+			</td>
+			<td class="centered">
+				<%= p = participant.college_degrees.from_clearinghouse_request(@clearinghouse_request.id); p.size unless p.empty? %>
+			</td>
+		</tr>
+	<% end %>
+	</tbody>
+</table>
+
+<div id="sidebar">
+	<p><%= link_to "Back to request", @clearinghouse_request, :class => "back button" %></p>
+	<p><small class="info">The <strong>Record Found</strong> column will show True if <em>any</em> Clearinghouse Request has ever returned a record for that person. It is not necessarily a result from this specific request. Enrollments and degrees are specific to this request, however.</small></p>
+</div>

--- a/app/views/clearinghouse_requests/show.html.erb
+++ b/app/views/clearinghouse_requests/show.html.erb
@@ -1,4 +1,7 @@
-<h1>Request #<%= @clearinghouse_request.id.to_s %></h1>
+<div class="inline">
+	<h1>Request #<%= @clearinghouse_request.id.to_s %></h1> &nbsp;
+	<%= content_tag :span, @clearinghouse_request.status, :class => "#{@clearinghouse_request.status} status tag" %>
+</div>
 
 <dl class="inline-definitions">
 	
@@ -34,10 +37,10 @@
 				<p>
 					<br /><%= link_to "Retrieve results now", retrieve_clearinghouse_request_path(@clearinghouse_request), :method => :post, :class => "download button" if @clearinghouse_request.retrievable? %>
 					<%= separator if @clearinghouse_request.retrievable? %>
-					<%= link_to_function "Upload results file", "$('upload_form').show()", :class => "save button" %>
+					<%= link_to_function "Upload results file", "$('#upload_form').show()", :class => "save button" %>
 				</p>
 				
-				<%- form_tag upload_clearinghouse_request_path(@clearinghouse_request), :id => 'upload_form', :style => "display:none", :multipart => true do |f| -%>
+				<%= form_tag upload_clearinghouse_request_path(@clearinghouse_request), :id => 'upload_form', :style => "display:none", :multipart => true do |f| -%>
 					<p><br />Upload the detail file that was returned by National Student Clearinghouse.</p>
 					<%= file_field_tag 'retrieved_file' %>
 					<%= submit_tag "Upload" %>
@@ -68,9 +71,9 @@
 			</li>
 			
 			<%- if @clearinghouse_request.retrieved? -%>
-				<%- @clearinghouse_request.files.each_with_index do |file, i| %>
+				<%- for file in @clearinghouse_request.files %>
 					<li>
-						<%= link_to h(File.basename(file)), file_clearinghouse_request_path(@clearinghouse_request, :file => i+1) %>
+						<%= link_to file, file_clearinghouse_request_path(@clearinghouse_request, :file => file) %>
 						<%= "(Aggregate report)" if File.basename(file).match("aggrrpt") %>
 						<%= "(Control report)" if File.basename(file).match("cntlrpt") %>
 					</li>
@@ -78,11 +81,21 @@
 			<% end %>
 		</ul>
 	</dd>
+	
+	<%- if @clearinghouse_request.submitted? -%>
+		<dt>Processing Log</dt>
+		<dd>
+			<code id="processing_log_container"><em>Loading...</em></code>
+		</dd>
+	<% end %>
 
 </dl>
-
-
 
 <div id="sidebar">
 	<p><%= link_to "Back to requests", clearinghouse_requests_path, :class => "back button" %></p>
 </div>
+
+<%= javascript_tag "$( function() {
+	$.ajax('#{refresh_status_clearinghouse_request_path(@clearinghouse_request, :current_status => @clearinghouse_request.status)}', 
+		{ dataType: 'script' })
+	})" if @clearinghouse_request.submitted? %>

--- a/app/views/clearinghouse_requests/show.html.erb
+++ b/app/views/clearinghouse_requests/show.html.erb
@@ -56,6 +56,8 @@
 		<%- if @clearinghouse_request.retrieved? -%>
 			<%= @clearinghouse_request.retrieved_at.to_s(:date_with_full_month) %>
 			with <%= pluralize @clearinghouse_request.number_of_records_returned, "record" %>
+			
+			<p><br /><%= link_to "List results", results_clearinghouse_request_path(@clearinghouse_request), :class => "list button" %></p>
 		<% else %>
 			<%= content_tag(:em, "Not retrieved", :class => 'light') %>
 		<% end %>

--- a/app/views/college_enrollments/show.html.erb
+++ b/app/views/college_enrollments/show.html.erb
@@ -29,7 +29,7 @@
 
 	<dt>Source</dt>
 	<dd><%=h @college_enrollment.source.try(:titleize) %>
-		<%= " &ndash; " + link_to("Request ##{@college_enrollment.clearinghouse_request.id.to_s}", @college_enrollment.clearinghouse_request) if @college_enrollment.clearinghouse_request %>
+		<%= " &ndash; ".html_safe + link_to("Request ##{@college_enrollment.clearinghouse_request.id.to_s}", @college_enrollment.clearinghouse_request) if @college_enrollment.clearinghouse_request %>
 		</dd>
 
 </dl>

--- a/app/workers/clearinghouse_request_worker.rb
+++ b/app/workers/clearinghouse_request_worker.rb
@@ -1,0 +1,19 @@
+class ClearinghouseRequestWorker
+  include Sidekiq::Worker
+
+  def perform(clearinghouse_request_id, file_path)
+    begin
+      ActiveRecord::Base.connection_pool.with_connection do
+        request = ClearinghouseRequest.find(clearinghouse_request_id)
+        request.logger.info { "[ClearinghouseRequest #{clearinghouse_request_id.to_s}] Processing request file" }
+        request.process_detail_file(file_path)
+        request.logger.info { "[ClearinghouseRequest #{clearinghouse_request_id.to_s}] Done." }
+        request.store_permanently!(request.logger.instance_variable_get(:@logdev).filename)
+      end
+    rescue => e
+      request.logger.error { "[ClearinghouseRequest #{clearinghouse_request_id.to_s}] ERROR: #{e.message}" }
+      Rollbar.error(e, :clearinghouse_request_id => clearinghouse_request_id)
+    end
+  end
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -156,6 +156,7 @@ Dreamsis::Application.routes.draw do
       post :retrieve
       get :file
       post :upload
+      get :refresh_status
     end
   end
   match '/my/mentees' => 'participants#mentor', :as => :my_participants, :mentor_id => 'me'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -157,6 +157,7 @@ Dreamsis::Application.routes.draw do
       get :file
       post :upload
       get :refresh_status
+      get :results
     end
   end
   match '/my/mentees' => 'participants#mentor', :as => :my_participants, :mentor_id => 'me'

--- a/db/migrate/20150410053406_add_files_array_to_clearinghouse_request.rb
+++ b/db/migrate/20150410053406_add_files_array_to_clearinghouse_request.rb
@@ -1,0 +1,5 @@
+class AddFilesArrayToClearinghouseRequest < ActiveRecord::Migration
+  def change
+    add_column :clearinghouse_requests, :filenames, :text
+  end
+end

--- a/db/migrate/20150423040511_add_clearinghouse_record_found_to_people.rb
+++ b/db/migrate/20150423040511_add_clearinghouse_record_found_to_people.rb
@@ -1,0 +1,7 @@
+class AddClearinghouseRecordFoundToPeople < ActiveRecord::Migration
+  def change
+    unless column_exists? :people, :clearinghouse_record_found
+      add_column :people, :clearinghouse_record_found, :boolean
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150410053406) do
+ActiveRecord::Schema.define(:version => 20150423040511) do
 
   create_table "activity_logs", :force => true do |t|
     t.date     "start_date"
@@ -726,6 +726,7 @@ ActiveRecord::Schema.define(:version => 20150410053406) do
     t.boolean  "subsidized_housing"
     t.boolean  "immigrant"
     t.datetime "uwfs_training_date"
+    t.boolean  "clearinghouse_record_found"
   end
 
   add_index "people", ["college_attending_id"], :name => "index_people_on_college_attending_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150325204841) do
+ActiveRecord::Schema.define(:version => 20150410053406) do
 
   create_table "activity_logs", :force => true do |t|
     t.date     "start_date"
@@ -54,6 +54,7 @@ ActiveRecord::Schema.define(:version => 20150325204841) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "detail_report_filename"
+    t.text     "filenames"
   end
 
   create_table "college_applications", :force => true do |t|

--- a/lib/national_student_clearinghouse.rb
+++ b/lib/national_student_clearinghouse.rb
@@ -58,6 +58,7 @@ class NationalStudentClearinghouse
     ensure
       file.close unless file == nil
     end
+    request.store_permanently!(local_send_file_path)
     local_send_file_path
   end
   
@@ -219,7 +220,10 @@ class NationalStudentClearinghouse
     if match = File.read(file_path).match(/DreamSIS-ClearinghouseRequest(\d+)/i)
       Rails.logger.info { "Matched DreamSIS indicator in file contents - request ID is #{match[1].to_i}" }
       cr = ClearinghouseRequest.find(match[1].to_i)
-      cr.process_detail_file(file_path)
+      Rails.logger.info { "Storing file in persistent store" }
+      cr.store_permanently!(file_path)
+    	Rollbar.warning "Sidekiq not running" unless Report.sidekiq_ready?
+      ClearinghouseRequestWorker.perform_async(self.id, file_path)
     else 
       Rails.logger.info { "Did not match DreamSIS indicator in file contents! Quitting." }
     end


### PR DESCRIPTION
The major improvement with these changes is background processing of
the NSC file using sidekiq, but also includes many improvements to the
UX and flow, including:

* all files (generated and returned) are uploaded to S3 for long-term
storage instead of storing locally
* a custom log file is created and made available for the user to
inspect the full history of processing the return file
* the log file is ajax-updated as the file is processed
* bug fixes like fixing `Institution.find_by_opeid` so that the NSC
results will properly find institution records