### PR TITLE
Use Logentries for clearinghouse logs across cluster

### DIFF
--- a/app/controllers/clearinghouse_requests_controller.rb
+++ b/app/controllers/clearinghouse_requests_controller.rb
@@ -11,6 +11,7 @@ class ClearinghouseRequestsController < ApplicationController
   
   def show
     @clearinghouse_request = ClearinghouseRequest.find(params[:id])
+    flash[:notice] = params[:message] if params[:message]
   
     respond_to do |format|
       format.html # show.html.erb
@@ -35,16 +36,19 @@ class ClearinghouseRequestsController < ApplicationController
   def file
     @clearinghouse_request = ClearinghouseRequest.find(params[:id])
     if params[:file] == 'submission'
-      file_url = @clearinghouse_request.file_url(@clearinghouse_request.nsc.send_filename)
+      file_url = @clearinghouse_request.file_url(:submission)
     elsif !params[:file].blank?
       file_url = @clearinghouse_request.file_url(params[:file])
     end
     redirect_to file_url
+  rescue KeyError => e
+    flash[:error] = "The requested file is not included in the list of available files for this request."
+    redirect_to :back
   end
   
   def refresh_status
     @clearinghouse_request = ClearinghouseRequest.find(params[:id])
-    @output = File.read(@clearinghouse_request.logger.instance_variable_get(:@logdev).filename)
+    @output = @clearinghouse_request.log_contents
     
     respond_to do |format|
       format.js

--- a/app/views/clearinghouse_requests/refresh_status.js.erb
+++ b/app/views/clearinghouse_requests/refresh_status.js.erb
@@ -13,6 +13,6 @@
     
 <%- end %>
 
-<%- if params[:current_status] != 'retrieved' && @clearinghouse_request.retrieved? -%>
-  window.location = "<%=j clearinghouse_request_path(@clearinghouse_request) %>"
+<%- if @clearinghouse_request.retrieved? -%>
+  window.location = "<%=j clearinghouse_request_path(@clearinghouse_request, :message => 'Done processing!') %>"
 <%- end %>

--- a/app/views/clearinghouse_requests/show.html.erb
+++ b/app/views/clearinghouse_requests/show.html.erb
@@ -73,18 +73,18 @@
 			</li>
 			
 			<%- if @clearinghouse_request.retrieved? -%>
-				<%- for file in @clearinghouse_request.files %>
+				<%- for file_name, index in @clearinghouse_request.files.each_with_index %>
 					<li>
-						<%= link_to file, file_clearinghouse_request_path(@clearinghouse_request, :file => file) %>
-						<%= "(Aggregate report)" if File.basename(file).match("aggrrpt") %>
-						<%= "(Control report)" if File.basename(file).match("cntlrpt") %>
+						<%= link_to file_name, file_clearinghouse_request_path(@clearinghouse_request, :file => index) %>
+						<%= "(Aggregate report)" if File.basename(file_name).match("aggrrpt") %>
+						<%= "(Control report)" if File.basename(file_name).match("cntlrpt") %>
 					</li>
 				<% end %>
 			<% end %>
 		</ul>
 	</dd>
 	
-	<%- if @clearinghouse_request.submitted? -%>
+	<%- if @clearinghouse_request.submitted? && !@clearinghouse_request.retrieved? -%>
 		<dt>Processing Log</dt>
 		<dd>
 			<code id="processing_log_container"><em>Loading...</em></code>
@@ -100,4 +100,4 @@
 <%= javascript_tag "$( function() {
 	$.ajax('#{refresh_status_clearinghouse_request_path(@clearinghouse_request, :current_status => @clearinghouse_request.status)}', 
 		{ dataType: 'script' })
-	})" if @clearinghouse_request.submitted? %>
+	})" if @clearinghouse_request.submitted? && !@clearinghouse_request.retrieved? %>

--- a/app/workers/clearinghouse_request_worker.rb
+++ b/app/workers/clearinghouse_request_worker.rb
@@ -5,13 +5,13 @@ class ClearinghouseRequestWorker
     begin
       ActiveRecord::Base.connection_pool.with_connection do
         request = ClearinghouseRequest.find(clearinghouse_request_id)
-        request.logger.info { request.log_prefix + "Processing request file" }
+        request.log "Processing request file"
         request.process_detail_file(file_path)
-        request.logger.info { request.log_prefix + "Done." }
+        request.log "Done."
         request.store_permanently!(request.logger.instance_variable_get(:@logdev).filename)
       end
     rescue => e
-      request.logger.error { request.log_prefix + "ERROR: #{e.message}" }
+      request.log "ERROR: #{e.message}", :error
       Rollbar.error(e, :clearinghouse_request_id => clearinghouse_request_id)
     end
   end

--- a/app/workers/clearinghouse_request_worker.rb
+++ b/app/workers/clearinghouse_request_worker.rb
@@ -5,13 +5,13 @@ class ClearinghouseRequestWorker
     begin
       ActiveRecord::Base.connection_pool.with_connection do
         request = ClearinghouseRequest.find(clearinghouse_request_id)
-        request.logger.info { "[ClearinghouseRequest #{clearinghouse_request_id.to_s}] Processing request file" }
+        request.logger.info { request.log_prefix + "Processing request file" }
         request.process_detail_file(file_path)
-        request.logger.info { "[ClearinghouseRequest #{clearinghouse_request_id.to_s}] Done." }
+        request.logger.info { request.log_prefix + "Done." }
         request.store_permanently!(request.logger.instance_variable_get(:@logdev).filename)
       end
     rescue => e
-      request.logger.error { "[ClearinghouseRequest #{clearinghouse_request_id.to_s}] ERROR: #{e.message}" }
+      request.logger.error { request.log_prefix + "ERROR: #{e.message}" }
       Rollbar.error(e, :clearinghouse_request_id => clearinghouse_request_id)
     end
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,7 +39,7 @@ module Dreamsis
     config.encoding = "utf-8"
 
     # Configure sensitive parameters which will be filtered from the log file.
-    config.filter_parameters += [:password]
+    config.filter_parameters += [:password, :regid, :state, :code]
 
     # Enable the asset pipeline
     config.assets.enabled = true

--- a/config/initializers/logentries.rb
+++ b/config/initializers/logentries.rb
@@ -1,5 +1,5 @@
 if API_KEYS["logentries"]
-  token = API_KEYS["logentries"][Rails.env]
+  token = API_KEYS["logentries"][Rails.env]["default"]
   Rails.logger = Le.new(token, :debug => true, :local => true, :ssl => true, :tag => true)
   
   # Tag log entries with the server ID and the rails environment


### PR DESCRIPTION
Also includes some other clearinghouse improvements, like using the
file ID in ClearinghouseRequestsController#file instead of the
filename, per CodeClimate’s recommendation.