### PR TITLE
Major fix: Filtering on events by shifts now works.

### DIFF
--- a/app/assets/stylesheets/dreamsis.css
+++ b/app/assets/stylesheets/dreamsis.css
@@ -4586,6 +4586,7 @@ ul.mentor_stats_summary .section_id.tag {
 .signup-numbers {
 	font-size: 85%;
 	color: #656565;
+	clear: both;
 }
 
 .signup-numbers span {

--- a/app/views/event_attendances/index.html.erb
+++ b/app/views/event_attendances/index.html.erb
@@ -1,91 +1,123 @@
 <h3 class="pre-title"><%= @event.name %></h3>
 <h1><%=h @audience.to_s %> Attendance</h1>
-	
+    
 <table class="attendees">
-	<thead>
-		<tr>
-			<th>Attendee</th>
-			<%= content_tag(:th, "High School") if @audience.to_s.downcase == "participant" || @audience.to_s.downcase == "student" %>
-			<th>Program(s)</th>
-			<th>Phone</th>
-			<th>Shift</th>
-			<%= "<th class='centered'>Trained?</th>" if @event.training_required?(@audience.to_s) %>
-			<th class="centered">RSVP'd?
-				<%= link_to "E-mail",
-				 				"mailto:#{@event.attendees.rsvpd(@audience).collect{|a| a.email rescue nil }.compact.join(",")}",
-								:class => 'email button',
-								:id => 'attending_email_link' %>
-				</th>
-			<th class="centered">Attended?
-				<%= link_to "E-mail",
-				 				"mailto:#{@event.attendees.attended(@audience).collect{|a| a.email rescue nil }.compact.join(",")}",
-								:class => 'email button',
-								:id => 'attended_email_link' %>
-				</th>
-			<th>Functions</th>
-		</tr>
-	</thead>
+    <thead>
+        <tr>
+            <th>Attendee</th>
+            <%= content_tag(:th, "High School") if @audience.to_s.downcase == "participant" || @audience.to_s.downcase == "student" %>
+            <th>Program(s)</th>
+            <th>Phone</th>
+            <th>Shift</th>
+            <%= "<th class='centered'>Trained?</th>" if @event.training_required?(@audience.to_s) %>
+            <th class="centered">RSVP'd?
+                <%= link_to "E-mail",
+                                "mailto:#{@event.attendees.rsvpd(@audience).collect{|a| a.email rescue nil }.compact.join(",")}",
+                                :class => 'email button',
+                                :id => 'attending_email_link' %>
+                </th>
+            <th class="centered">Attended?
+                <%= link_to "E-mail",
+                                "mailto:#{@event.attendees.attended(@audience).collect{|a| a.email rescue nil }.compact.join(",")}",
+                                :class => 'email button',
+                                :id => 'attended_email_link' %>
+                </th>
+            <th>Functions</th>
+        </tr>
+    </thead>
 
-	<tbody>
-		<%= render :partial => 'event_attendance', :collection => @event.attendees.audience(@audience).select{|a| a.rsvp? || a.attended? || a.admin? }, :locals => { :audience => @audience } %>
+    <tbody>
+        <%= render :partial => 'event_attendance', :collection => @event.attendees.audience(@audience).select{|a| a.rsvp? || a.attended? || a.admin? }, :locals => { :audience => @audience } %>
 
-		<%- if @event.attendees.empty? -%>
-			<tr class="empty">
-				<td colspan=10>No event attendees yet.</td>
-			</tr>
-		<% end -%>
-	</tbody>
+        <%- if @event.attendees.empty? -%>
+            <tr class="empty">
+                <td colspan=10>No event attendees yet.</td>
+            </tr>
+        <% end -%>
+    </tbody>
 </table>
 
 <div id="sidebar">
-	<p><%= link_to "Back to Event", event_path(@event), :class => 'back button' %></p>
-	<p><%= link_to "Take Attendnace", checkin_event_event_attendances_path(@event, :audience => @audience), :class => "edit button" %></p>
-	
-	<%- form_tag({}, :method => :get) do -%>
-		<p><%= label_tag :audience, "View Attendance For:" %>
-			<%= select_tag :audience,
-							options_for_select(%w[Participant Student Mentor Volunteer].collect{|a| ["#{a} (#{@event.rsvpd_count(a)})", a]}, 
-							@audience.to_s.classify),
-							:onchange => "this.form.submit()" %>
-			<%= submit_tag "Go" %>
-		</p>
-	<% end -%>
+    <p><%= link_to "Back to Event", event_path(@event), :class => 'back button' %></p>
+    <p><%= link_to "Take Attendnace", checkin_event_event_attendances_path(@event, :audience => @audience), :class => "edit button" %></p>
+    
+    <%- form_tag({}, :method => :get) do -%>
+        <p><%= label_tag :audience, "View Attendance For:" %>
+            <%= select_tag :audience,
+                            options_for_select(%w[Participant Student Mentor Volunteer].collect{|a| ["#{a} (#{@event.rsvpd_count(a)})", a]}, 
+                            @audience.to_s.classify),
+                            :onchange => "this.form.submit()" %>
+            <%= submit_tag "Go" %>
+        </p>
+    <% end -%>
 
-	<%- if @event.has_shifts?(@audience.to_s.classify) %>
-		<h3>Filter by Shift</h3>
-		
-		<div id="event_shift_selectors">
-		<%- for event_shift in @event.shifts.for(@audience.to_s.classify) -%>
-			<label for="event_shift_selector_<%= event_shift.id %>">
-				<input type="checkbox" id="event_shift_selector_<%= event_shift.id %>" data-shift-id="<%= event_shift.id %>" checked onChange="updateShiftSelections(this);">
-				<%= truncate(event_shift.title) %>
-			</label><br>
-		<% end -%>
-		<small class="light">Filtering the list will also update the email buttons above.</small>
-		</div>
-		
-	<% end -%>
+    <%- if @event.has_shifts?(@audience.to_s.classify) %>
+        <h3>Filter by Shift</h3>
+        
+        <div id="event_shift_selectors">
+        <%- for event_shift in @event.shifts.for(@audience.to_s.classify) -%>
+            <label for="event_shift_selector_<%= event_shift.id %>">
+                <input type="checkbox" id="event_shift_selector_<%= event_shift.id %>" data-shift-id="<%= event_shift.id %>" checked onChange="updateShiftSelections(this);">
+                <%= truncate(event_shift.title) %>
+            </label><br>
+        <% end -%>
+        <small class="light">Filtering the list will also update the email buttons above.</small>
+        </div>
+        
+    <% end -%>
 </div>
 
 <script type="text/javascript">
 
+function filterEvents() {
+
+}
+
+
 function updateShiftSelections(elem) {
-	var rows = $$("tr.event_attendance")
-	rows = rows.findAll(function(e) { return e.readAttribute('data-shift-id') == elem.readAttribute('data-shift-id') })
-	if(elem.checked == true) {
-		rows.invoke('show')
-	} else {
-		rows.invoke('hide')
-	}
-	updateEmailLinks()
+    // get the data shift id for the filter
+    var shiftid = elem.getAttribute("data-shift-id");
+
+    // get all rows that correspond to that shift id
+    var rows = $("tr.event_attendance[data-shift-id='" + shiftid + "']");
+
+    if (elem.checked)  {
+        rows.show();
+    } else {
+        rows.hide();
+    }
+    
+    updateEmailLinks();
 }
 
 function updateEmailLinks() {
-	var rows = $$("tr.event_attendance").findAll(function(e) { return e.visible() })
-	var attending_rows = rows.findAll(function(e) { return e.readAttribute("data-attending") == "true" })
-	var attended_rows =  rows.findAll(function(e) { return e.readAttribute("data-attended") == "true" })
-	$('attending_email_link').writeAttribute("href", "mailto:" + attending_rows.collect(function(e) { return e.readAttribute("data-email") }).join(","))
-	$('attended_email_link').writeAttribute("href",  "mailto:" + attended_rows.collect(function(e) {  return e.readAttribute("data-email") }).join(","))
+    // get rows which are visible and corresponding attributes are true
+    var attending_rows = $("tr.event_attendance[data-attending='true']:visible");
+    var attended_rows = $("tr.event_attendance[data-attended='true']:visible");
+
+    // create an email list of those people attending
+    var emailsAttending = [];
+    function getAttending() {
+        attending_rows.each(function(key, value) {             
+            emailsAttending.push(value.getAttribute('data-email'));
+        });
+    }
+    getAttending();
+
+    // make the array into string and then set that as a value to the email link 
+    emailsAttending = emailsAttending.splice(',').join(',');
+    $('#attending_email_link').attr("href",  "mailto:" + emailsAttending);
+
+    // similarly for the Attended emails
+    var emailsAttended = [];
+    function getAttended() {
+        attended_rows.each(function(key, value) {             
+            emailsAttended.push(value.getAttribute('data-email'));
+        });
+    }
+    getAttended();
+    emailsAttended = emailsAttended.splice(',').join(',');
+    $('#attended_email_link').attr("href",  "mailto:" + emailsAttended);
 }
 
 </script>

--- a/app/views/events/_details.html.erb
+++ b/app/views/events/_details.html.erb
@@ -26,7 +26,7 @@
 				 title="<%= number_to_percentage details.percent_full, :precision => 0 %> full">
 
 				<div class="size" style="width: <%= details.percent_full %>%">
-					<%= details.full? ? content_tag(:span, "full", :class => "full_label") : "&nbsp;" %>
+					<%= details.full? ? content_tag(:span, "full", :class => "full_label") : "&nbsp;".html_safe %>
 				</div>					
 			</div>
 		</div>


### PR DESCRIPTION
Three files were updated. Details as follows. 
Index.html: Filtering on events by shifts is now fixed and working. 
CSS changes: minor, so that participant number shows up aligned on event pages. [Minor]
_details changes: html safe on a no break. [Minor]