### PR TITLE
Allows non-owners to clear the follow-up flag on notes

### DIFF
--- a/app/assets/stylesheets/dreamsis.css.erb
+++ b/app/assets/stylesheets/dreamsis.css.erb
@@ -4465,6 +4465,11 @@ div.notes.editable, p.notes.editable {
   color: rgba(0,0,0,0.5);
   margin-left: 1em;
   margin-top: 0;
+  margin-bottom: 0;
+}
+
+.notes .timestamp:last-child {
+  margin-bottom: 1em;
 }
 
 .notes blockquote .controls {

--- a/app/controllers/changes_controller.rb
+++ b/app/controllers/changes_controller.rb
@@ -1,6 +1,6 @@
 class ChangesController < ApplicationController
   
-  ALLOWABLE_MODELS = %w[Person User Participant Mentor Volunteer PubcookieUser CollegeApplication ScholarshipApplication]
+  ALLOWABLE_MODELS = %w[Person User Participant Mentor Volunteer PubcookieUser CollegeApplication ScholarshipApplication Note]
   
   # GET /changes/for/:model_name/:id
   def for_object

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -48,25 +48,16 @@ class NotesController < ApplicationController
     end
   end
     
-  # def document
-  #     @note = Note.find(params[:id])
-  #
-  #     if @note.notable.is_a?(Person)
-  #       @person = @note.notable
-  #       unless @current_user && @current_user.can_view?(@person)
-  #         return render_error("You are not allowed to view documents for that person.")
-  #       end
-  #     end
-  #
-  #     send_data @note.document.read, :type => @note.document_content_type, :filename => @note.document_file_name
-  # end
-
   protected
   
   def verify_permissions
     @note = Note.find params[:id]
-    unless @note.user == @current_user
-      render_error("You can only edit or delete your own notes.")
+    if @note.user != @current_user && @current_user.can_edit?(@note.notable) && params[:note].try(:[], :needs_followup)
+      # The user is trying to change the followup flag, and has permission. Allow *only* this change.
+      params[:note] = { :needs_followup => params[:note].try(:[], :needs_followup) }
+    else
+      # The user does not own the note and cannot edit it.
+      render_error("You can only edit or delete your own notes.") unless @note.user == @current_user
     end
   end
   

--- a/app/models/people/participant.rb
+++ b/app/models/people/participant.rb
@@ -390,7 +390,9 @@ class Participant < Person
   # * event_attendances
   def child_objects
     collections = %w[college_applications scholarship_applications parents test_scores 
-                     college_enrollments college_degrees mentor_participants event_attendances]
+                     college_enrollments college_degrees mentor_participants event_attendances
+                     notes
+                   ]
     child_objects = []
     for collection in collections
       child_objects << self.instance_eval(collection)

--- a/app/views/shared/_note.html.erb
+++ b/app/views/shared/_note.html.erb
@@ -41,4 +41,12 @@
 	</div>
 	
 	<p class="timestamp"><%= relative_timestamp note.created_at %></p>
+	
+	<%- for change in note.changelogs.select{|ch| ch.action_type == "update" && ch.changes.keys.include?("needs_followup") } -%>
+		<p class="timestamp">
+			<%= relative_timestamp(change.created_at) %> &ndash;
+			<%= change.user.nil? ? "The system" : link_to(h(change.user.try(:fullname)), user_path(change.user)) %>
+			<%= change.changes["needs_followup"][1] == false ? "cleared" : "set" %> the follow-up flag.
+		</p>
+	<% end %>
 </blockquote>

--- a/config/initializers/active_record_extensions.rb
+++ b/config/initializers/active_record_extensions.rb
@@ -8,7 +8,7 @@ end
 
 module ChangeLogged
   def self.append_features(base_class)
-    base_class.has_many :changelogs, :as => :change_loggable, :class_name => 'Change'
+    base_class.has_many :changelogs, :as => :change_loggable, :class_name => 'Change', :foreign_key => "change_loggable_id"
     base_class.after_create { |record| Change.log_create(record) }
     base_class.after_update { |record| Change.log_update(record) }
     base_class.after_destroy { |record| Change.log_delete(record) }


### PR DESCRIPTION
These changes fix a practical bug where users who have permission to view and edit a participant record can't clear the "Needs Followup" flag on notes. By default, only the owner of a note can edit it, but this flag needs to be editable by others who have access to the participant's record, especially when the person who set the flag is no longer engaged with the student and another mentor has taken over.

Additionally these changes enable audit tracking for Notes, and displays a change history for Notes where the follow-up flag has been changed. This allows a person viewing a participant's record to see when a particular follow-up flag was cleared and by whom. 