### PR TITLE
Adds categories to stat filters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ gem "simple_calendar", "~> 1.1.0"
 gem 'jquery-tablesorter'
 gem 'le'
 gem 'coderay', :require =>  'coderay'
+gem 'acts_as_list'
 
 group :production do
   gem 'mysql2', '~> 0.3.7'

--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ gem 'apartment-sidekiq'
 gem "simple_calendar", "~> 1.1.0"
 gem 'jquery-tablesorter'
 gem 'le'
+gem 'coderay', :require =>  'coderay'
 
 group :production do
   gem 'mysql2', '~> 0.3.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,7 @@ GEM
       mime-types (>= 1.16)
     celluloid (0.16.0)
       timers (~> 4.0.0)
+    coderay (1.1.0)
     coffee-rails (3.2.2)
       coffee-script (>= 2.2.0)
       railties (~> 3.2.0)
@@ -302,6 +303,7 @@ DEPENDENCIES
   bcrypt-ruby (~> 3.0.0)
   byebug
   carrierwave
+  coderay
   coffee-rails
   country_select (~> 1.3.1)
   ey_config

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,8 @@ GEM
     activesupport (3.2.19)
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
+    acts_as_list (0.7.2)
+      activerecord (>= 3.0)
     acts_as_xlsx (1.0.6)
       activerecord (>= 2.3.9)
       axlsx (>= 1.0.13)
@@ -293,6 +295,7 @@ PLATFORMS
 
 DEPENDENCIES
   RedCloth
+  acts_as_list
   acts_as_xlsx
   addressable
   aes

--- a/app/assets/javascripts/dreamsis.js
+++ b/app/assets/javascripts/dreamsis.js
@@ -125,6 +125,15 @@ function updateActivityTimeDescription(elem) {
 function registerTableSorters() {
   $("th.functions").addClass("sorter-false")
   $(":not(.calendar) > table:not(.no-sort)").tablesorter({ theme: "dreamsis", sortStable: true })
+
+  $("table.object_filters > tbody").sortable({ 
+    axis: 'y', 
+    cursor: 'move',
+    handle: '.handle',
+    update: function(elem) {
+      $.post($(this).data('update-url'), $(this).sortable('serialize'))
+    }
+  })
 }
 
 /*

--- a/app/assets/javascripts/filterable.js
+++ b/app/assets/javascripts/filterable.js
@@ -3,6 +3,7 @@ $( function() {
   executeFilters()
   $(".filter_checkbox").click(clickFilterCheckbox)
   $("#stages_selector a").click(clickStageSelector) // Add this after the ajax call, too
+  $("ul.filters li.category h4").click(function() { $(this).parents('li.category').toggleClass('closed') })
 })
 
 function executeFilters() {
@@ -20,10 +21,12 @@ function executeFilters() {
     // Add rows that match the selected filters
     $(".filter_checkbox.enabled").each(function (i, element) {
       selection += "[data-filter-" + $(this).data("target-filter-id") + "='" + $(this).val() + "']"
+      $(this).parents('li.category').removeClass('closed')
     })
 
     // Show all the rows in the selection
     $(selection).removeClass("hidden")
+    $(".filter-clear-link").show()
   }
   updateRecordCount()
 }
@@ -31,6 +34,7 @@ function executeFilters() {
 // shows all the filterable items to give us a clean slate before running executeFilters()
 function showAllFilterables() {
   $(".filterable").removeClass("hidden")
+  $(".filter-clear-link").hide()
 }
 
 // // Adds the "preview_filter" CSS class to the filter elements but doesn't hide them
@@ -50,6 +54,18 @@ function clearAllFilters() {
   $('.filter_checkbox').removeAttr("checked").removeClass("enabled") // uncheck all the boxes to start
   updateRecordCount()
   updateLocationHashWithFilters()
+}
+
+function toggleExpandFiltersView() {
+  if( $('ul.filters').is('.expanded') ) {
+    $('ul.filters li.category').addClass("closed")
+    $('ul.filters').removeClass("expanded")
+    $('.filter-expand-link').html("Expand")
+  } else {
+    $('ul.filters li.category').removeClass("closed")
+    $('ul.filters').addClass("expanded")
+    $('.filter-expand-link').html("Collapse")
+  }
 }
 
 // Tries to update a div with id "filtered_record_count" with the number of filterables that are visible.
@@ -160,8 +176,8 @@ function updateLocationHashWithFilters() {
 /*
   Updates filter selections with the values in the location hash.
 */
-function updateFiltersWithLocationHash() {
-  var currentHash = window.location.hash
+function updateFiltersWithLocationHash(otherHash) {
+  var currentHash = otherHash || window.location.hash
   var hashParts = currentHash.replace("#!", "").split("&")
   for (var i=0; i < hashParts.length; i++) {
     if (hashParts[i].length > 0) {      
@@ -187,3 +203,4 @@ function updateFiltersWithLocationHash() {
     executeFilters()
   }
 }
+

--- a/app/assets/javascripts/filterable.js
+++ b/app/assets/javascripts/filterable.js
@@ -4,6 +4,7 @@ $( function() {
   $(".filter_checkbox").click(clickFilterCheckbox)
   $("#stages_selector a").click(clickStageSelector) // Add this after the ajax call, too
   $("ul.filters li.category h4").click(function() { $(this).parents('li.category').toggleClass('closed') })
+  removeCategoriesIfEmpty()    
 })
 
 function executeFilters() {
@@ -204,3 +205,13 @@ function updateFiltersWithLocationHash(otherHash) {
   }
 }
 
+/*
+  If there is only one category or none, expand it and hide the expanding buttons
+*/
+function removeCategoriesIfEmpty() {
+  if ($('ul.filters li.category').size() < 2) {
+    $('ul.filters li.category').removeClass("closed")
+    $("ul.filters li.category h4").hide()
+    $('.filter-expand-link').hide()
+  }
+}

--- a/app/assets/stylesheets/dreamsis.css.erb
+++ b/app/assets/stylesheets/dreamsis.css.erb
@@ -663,6 +663,16 @@ body.scrolled-past-header ul.tabs {
 	font-family: "Oxygen", sans-serif;
 }
 
+#sidebar h3 > a.right {
+  margin-left: 1em;
+  font-weight: normal;
+  text-decoration: none;
+}
+
+#sidebar h3 > a.right:hover {
+  text-decoration: underline;
+}
+
 #sidebar :first-child {
 	margin-top: 0;
 }
@@ -3375,9 +3385,39 @@ ul.filters {
 	margin: 0;
 }
 
+ul.filters ul {
+  list-style: none;
+  padding-left: 0.5em;
+  padding-top: 3px;
+}
+
+ul.filters li ul { 
+  transition: opacity 0.5s, height 0.5s;
+  overflow: hidden;
+}
+
+ul.filters li.closed ul {
+  opacity: 0;
+  height: 0;
+}
+
 .filters li {
 	clear: both;
 	margin-bottom: 5px;
+}
+
+.filters > li.category > h4 {
+	padding-top: 0.5em;
+  font-weight: bold;
+	text-transform: uppercase;
+	font-size: 85%;
+	font-family: "Oxygen", sans-serif;
+  cursor: pointer;
+}
+
+.filters > li.category:not(.closed) > h4:after, .filters > li.category:hover > h4:after {
+  content: '\25be';
+  padding-left: 0.35em;
 }
 
 .filters li:hover label small {

--- a/app/assets/stylesheets/dreamsis.css.erb
+++ b/app/assets/stylesheets/dreamsis.css.erb
@@ -130,6 +130,14 @@ a:visited {
 	margin-right: 1em;
 }
 
+.handle {
+  color: rgba(0,0,0,0.35);
+}
+
+.handle:hover {
+  cursor: move;
+}
+
 table {
 	width: 100%;
 	border-collapse: collapse;
@@ -2163,6 +2171,16 @@ ul.stat-numbers.progression li:last-child:after {
 	width: 30%;
 }
 
+.stats tr.category th {
+  padding-left: 10px !important;
+  padding-bottom: 5px !important;
+  background: none;
+}
+
+.stats tr.category:hover th {
+  background: none !important;
+}
+
 form.fixed-width label {
 	float: left;
 	width: 200px;
@@ -3480,18 +3498,29 @@ ul.filters li.closed ul {
 ul.filter-results {
 	list-style: none;
 	padding: 0;
-	margin: 20px 30px;
-	columns: 2;
-	-webkit-columns: 2;
+	margin: 10px 20px;
+	columns: 3;
+	-webkit-columns: 3;  
+}
+
+ul.filter-results li ul {
+	list-style: none;
+	padding: 0;
+  margin-bottom: 10px;
 }
 
 .filter-results li {
 	background: no-repeat left center;
 	padding: 7px;
-	padding-left: 22px;
 	border-bottom: 1px solid #eee;
 	-webkit-column-break-inside: avoid;
 	break-inside: avoid-column;
+	padding-left: 25px;
+}
+
+.filter-results li ul li {
+  border-bottom: none;
+  margin-left: 0px;
 }
 
 .filter-results li.pass, span.icon.pass {
@@ -4729,7 +4758,7 @@ table.documents tr:hover td.functions a {
 	padding-bottom: 1em;
 }
 
-#new_participant_form_container h2, new_volunteer_form_container h2 {
+#new_participant_form_container h2, #new_volunteer_form_container h2 {
 	margin: 0;
 	padding-bottom: 0.25em;
 	border-bottom: 1px solid #eee;
@@ -4741,6 +4770,10 @@ table.documents tr:hover td.functions a {
 
 table.object_filters td {
 	vertical-align: text-bottom;
+}
+
+table.object_filters tbody {
+  border-bottom: 15px solid rgba(0,0,0,0.03);
 }
 
 code {

--- a/app/controllers/object_filters_controller.rb
+++ b/app/controllers/object_filters_controller.rb
@@ -74,16 +74,6 @@ class ObjectFiltersController < ApplicationController
     end
   end
 
-  def formatted_criteria
-    @object_filter = ObjectFilter.find(params[:id])
-    code = @object_filter.criteria
-    request = Net::HTTP.post_form(URI.parse('http://pygments.appspot.com/'), {'lang' => 'ruby', 'code' => code})
-
-    respond_to do |format|
-      format.js { render :text => request.body }
-    end
-  end
-
   protected 
   
   def check_authorization

--- a/app/controllers/object_filters_controller.rb
+++ b/app/controllers/object_filters_controller.rb
@@ -1,7 +1,7 @@
 class ObjectFiltersController < ApplicationController
   
   def index
-    @object_filters = ObjectFilter.all
+    @object_filters = ObjectFilter.reorder("category IS NULL ASC, category, position")
 
     respond_to do |format|
       format.html # index.html.erb
@@ -72,6 +72,13 @@ class ObjectFiltersController < ApplicationController
       format.html { redirect_to(object_filters_url) }
       format.xml  { head :ok }
     end
+  end
+  
+  def sort
+    params[:object_filter].each_with_index do |id, index|
+      ObjectFilter.update_all({ position: index+1 }, { id: id })
+    end
+    render nothing: true
   end
 
   protected 

--- a/app/models/object_filter.rb
+++ b/app/models/object_filter.rb
@@ -6,7 +6,9 @@ class ObjectFilter < ActiveRecord::Base
   belongs_to :earliest_grade_level, :class_name => "GradeLevel", :primary_key => 'level', :foreign_key => 'earliest_grade_level_level'
   belongs_to :latest_grade_level, :class_name => "GradeLevel", :primary_key => 'level', :foreign_key => 'latest_grade_level_level'
 
-  default_scope :order => "earliest_grade_level_level, title"
+  default_scope :order => "category IS NULL, category, position, earliest_grade_level_level, title"
+
+  acts_as_list scope: [:category]
   
   # If there's a value in the +opposite_title+ attribute, then we'll display the opposite perspective on the filters
   # list on the participant list.

--- a/app/models/object_filter.rb
+++ b/app/models/object_filter.rb
@@ -34,6 +34,11 @@ class ObjectFilter < ActiveRecord::Base
     return false
   end
 
+  # Returns the human readable category name by looking up the value in Participant::FILTER_CATEGORIES.
+  def category_name
+    Participant::FILTER_CATEGORIES[category.to_sym] if category
+  end
+
   # Returns false unless start_display_at and end_display_at are not nil.
   def has_display_period?
     !start_display_at.nil? && !end_display_at.nil?

--- a/app/models/people/participant.rb
+++ b/app/models/people/participant.rb
@@ -43,6 +43,24 @@ class Participant < Person
 		"Earn GED",
 		"Don't know"
 	]
+  
+  # Stores the categories for Participant ObjectFilters. The key should match the dom_id
+  # of the category, and is also the key that gets displayed in the database.
+  FILTER_CATEGORIES = {
+    _general: "General",
+		contact: "Contact Information",
+		college_applications: "Colleges",
+		scholarship_applications: "Financial",
+		parents: "Parents/Contacts",
+		test_scores: "Tests",
+		college_enrollments: "College Enrollment",
+		college_degrees: "College Degrees",
+		mentors: "Mentors",
+		events: "Events",
+		paperwork: "Paperwork",
+		documents: "Documents",
+		notes: "Notes"
+  }
 
   def validate_name?
     true
@@ -73,7 +91,7 @@ class Participant < Person
   
   # Returns all Filter objects that list Participant as the object_class
   def self.object_filters
-    ObjectFilter.find_all_by_object_class("Participant").select(&:display_now?)
+    ObjectFilter.where(object_class: "Participant")
   end
 
   def method_missing(method_name, *args)

--- a/app/views/object_filters/_fields.html.erb
+++ b/app/views/object_filters/_fields.html.erb
@@ -20,18 +20,11 @@
 
 <%= f.inputs(:title => "Display Options") do %>
 	
-	<%#= f.input :opposite_title, :hint => "If you want this to show as an opposite filter in participant lists, enter a title here so that
-											the semantics will make sense. This might be useful so that you can filter for the people who 
-											have NOT completed this stat." %>
-								
-	<%#= f.inputs :name => "Display Period", :class => "inline" do -%>			
-		<%#= f.input :start_display_at, :label => "From", :order => [:month, :day] %>
-		<%#= f.input :end_display_at, :label => "To", :order => [:month, :day] %>
-	<%# end %>
-
 	<%= f.inputs :name => "Relevant Grade Levels", :class => "inline" do -%>			
 		<%= f.input :earliest_grade_level_level, :label => "From", :as => :select, :collection => GradeLevel.all.collect{|g| [g.title, g.level]} %>
 		<%= f.input :latest_grade_level_level, :label => "To", :as => :select, :collection => GradeLevel.all.collect{|g| [g.title, g.level]} %>
 	<% end %>
+	
+	<%= f.input :category, :collection => Participant::FILTER_CATEGORIES.invert %>
 											
 <% end -%>

--- a/app/views/object_filters/_high_school_stats.html.erb
+++ b/app/views/object_filters/_high_school_stats.html.erb
@@ -24,15 +24,24 @@ hide_title ||= false
 		<td class="number"><%= active_participants.size %></td>
 		<td></td>
 		<td class="percentage"><%= number_to_percentage(active_participants.size.to_f / participants.size.to_f * 100, :precision => 0) rescue 0.0/0.0 %></td>
-	</tr>
+	</tr>	
 	
+	<%- for category, object_filters in Participant.object_filters.group_by(&:category) -%>
+	<tr class="category">
+		<th colspan="10" data-category="<%= category %>">
+			<%= Participant::FILTER_CATEGORIES[category.to_s.to_sym] || "Other" %>
+		</th>
+	</tr>
+				
 	<%= render :partial => "object_filters/object_filter", 
-				:collection => Participant.object_filters,
+				:collection => object_filters,
 				:locals => { 
 					:participants => participants,
 					:active_participants => active_participants,
 					:hide_title => hide_title
 				} %>
+	
+	<% end %>
 
 </table>
 

--- a/app/views/object_filters/index.html.erb
+++ b/app/views/object_filters/index.html.erb
@@ -1,10 +1,9 @@
 <h1>Stat Filters</h1>
 <p>Filters are used to dynamically limit the students displayed on list pages, based on certain criteria defined here.</p>
 
-<table class="object_filters">
+<table class="object_filters no-sort">
 	<thead>
-		<tr>
-			<!-- <th>Object</th> -->
+		<tr><th></th>
 			<th>Category</th>
 			<th>Title</th>
 			<th>Target</th>
@@ -14,10 +13,11 @@
 		</tr>
 	</thead>
 
-	<tbody>
-		<% for object_filter in @object_filters %>
-		<tr>
-		   	<!-- <td><%=h object_filter.object_class %></td> -->
+	<%- for category, object_filters in @object_filters.group_by(&:category) -%>
+	<tbody data-update-url="<%= sort_object_filters_url %>">
+		<% for object_filter in object_filters %>
+		<tr id="object_filter_<%= object_filter.id %>">
+			<td class="handle">&#9776;</td>
 			<td><%=h object_filter.category_name %></td>
 			<td class="name">
 			   	<%= link_to h(object_filter.title), object_filter_path(object_filter), :title => h(object_filter.criteria) %>
@@ -38,6 +38,7 @@
 		</tr>
 		<% end %>
 	</tbody>
+	<% end %>
 
 </table>
 

--- a/app/views/object_filters/index.html.erb
+++ b/app/views/object_filters/index.html.erb
@@ -2,32 +2,43 @@
 <p>Filters are used to dynamically limit the students displayed on list pages, based on certain criteria defined here.</p>
 
 <table class="object_filters">
-  <tr>
-    <th>Object</th>
-    <th>Title</th>
-	<th>Target</th>
-	<th>Warning</th>
-	<th>Dates</th>
-	<th>Grades</th>
-	<th colspan=3>Functions</th>
-  </tr>
+	<thead>
+		<tr>
+			<!-- <th>Object</th> -->
+			<th>Category</th>
+			<th>Title</th>
+			<th>Target</th>
+			<th>Warning</th>
+			<th>Grades</th>
+			<th colspan=3>Functions</th>
+		</tr>
+	</thead>
 
-<% for object_filter in @object_filters %>
-  <tr>
-    <td><%=h object_filter.object_class %></td>
-    <td class="name">
-		<%= link_to h(object_filter.title), object_filter_path(object_filter), :title => h(object_filter.criteria) %>
-		<code class="criteria syntax" id="criteria_<%= object_filter.id %>" style="display:none"><%=h object_filter.criteria %></code>
-	</td>
-	<td><%=h number_to_percentage object_filter.target_percentage, :precision => 0 %></td>
-	<td><%=h number_to_percentage object_filter.warning_threshold, :precision => 0 %></td>
-	<td><%= object_filter.display_period_string %></td>
-	<td><%= object_filter.grade_levels_list_string %></td>
-    <td class="functions"><%= link_to 'Show', object_filter_path(object_filter) %></td>
-    <td class="functions"><%= link_to 'Edit', edit_object_filter_path(object_filter) %></td>
-    <td class="functions"><%= link_to 'Destroy', object_filter_path(object_filter), :confirm => 'Are you sure?', :method => :delete %></td>
-  </tr>
-<% end %>
+	<tbody>
+		<% for object_filter in @object_filters %>
+		<tr>
+		   	<!-- <td><%=h object_filter.object_class %></td> -->
+			<td><%=h object_filter.category_name %></td>
+			<td class="name">
+			   	<%= link_to h(object_filter.title), object_filter_path(object_filter), :title => h(object_filter.criteria) %>
+				<code data-id="<%= object_filter.id %>" class="criteria syntax" id="criteria_<%= object_filter.id %>" style="display:none">
+					<%=raw CodeRay.scan(object_filter.criteria, :ruby).html(
+							:wrap => nil,
+							:line_numbers => nil,
+							:css => :style
+					) %>
+				</code>
+			</td>
+			<td><%=h number_to_percentage object_filter.target_percentage, :precision => 0 %></td>
+			<td><%=h number_to_percentage object_filter.warning_threshold, :precision => 0 %></td>
+			<td><%= object_filter.grade_levels_list_string %></td>
+			<td class="functions"><%= link_to 'Show', object_filter_path(object_filter) %></td>
+			<td class="functions"><%= link_to 'Edit', edit_object_filter_path(object_filter) %></td>
+			<td class="functions"><%= link_to 'Destroy', object_filter_path(object_filter), :confirm => 'Are you sure?', :method => :delete %></td>
+		</tr>
+		<% end %>
+	</tbody>
+
 </table>
 
 <div id="sidebar">
@@ -41,19 +52,3 @@
 	
 </div>
 
-<%= javascript_tag do %>
-	<%- for object_filter in @object_filters -%>
-	
-		$( function() {
-			$.ajax({ 
-				url: '<%= formatted_criteria_object_filter_path(object_filter) %>', 
-				dataType: 'text', 
-				type: 'post',
-				success: function(data) {
-					$("#criteria_<%= object_filter.id %>").html(data)
-				}
-			});
-		});
-	
-	<% end %>
-<% end %>

--- a/app/views/participants/_filter_controls.html.erb
+++ b/app/views/participants/_filter_controls.html.erb
@@ -1,0 +1,32 @@
+<h3>Filters
+	<%= link_to_function "clear", "clearAllFilters()", :class => "right small filter-clear-link", :style => "display:none" %>
+	<%= link_to_function "expand", "toggleExpandFiltersView()", :class => "right small filter-expand-link" %>
+</h3>
+
+	<ul class="filters">
+		<%- for category, object_filters in Participant.object_filters.reorder("category IS NULL ASC, category").group_by(&:category) -%>
+	
+		<li class="category <%= "closed" unless category.to_s.starts_with?("_") %>" data-category="<%= category %>">
+			<h4><%= Participant::FILTER_CATEGORIES[category.to_s.to_sym] || "Other" %></h4>
+			<ul>
+					
+				<%- for object_filter in object_filters -%>
+				<li id="filter_li_<%= object_filter.id.to_s %>" data-category="<%= object_filter.category.to_s %>">		
+
+					<% 
+					dom_id = "filter_#{object_filter.id.to_s}_true"
+					check_box_str = check_box_tag dom_id, true, false, 
+						:class => "#{object_filter.id.to_s}_filter_checkbox filter_checkbox", 
+						"data-target-filter-id" => object_filter.id.to_s
+					record_count_str = "<small id='record_count_#{object_filter.id}'>&nbsp;</small>"
+					%>
+					<%= label_tag(dom_id, raw("#{check_box_str}#{record_count_str}<span>#{object_filter.opposite_title}</span>")) %>
+
+				</li>
+				<% end %>
+				
+			</ul>
+		</li>
+	
+		<% end -%>
+	</ul>

--- a/app/views/participants/_filter_controls.html.erb
+++ b/app/views/participants/_filter_controls.html.erb
@@ -20,7 +20,7 @@
 						"data-target-filter-id" => object_filter.id.to_s
 					record_count_str = "<small id='record_count_#{object_filter.id}'>&nbsp;</small>"
 					%>
-					<%= label_tag(dom_id, raw("#{check_box_str}#{record_count_str}<span>#{object_filter.opposite_title}</span>")) %>
+					<%= label_tag(dom_id, raw("#{check_box_str}#{record_count_str}<span>#{h(object_filter.opposite_title)}</span>")) %>
 
 				</li>
 				<% end %>

--- a/app/views/participants/_filter_controls.html.erb
+++ b/app/views/participants/_filter_controls.html.erb
@@ -4,7 +4,7 @@
 </h3>
 
 	<ul class="filters">
-		<%- for category, object_filters in Participant.object_filters.reorder("category IS NULL ASC, category").group_by(&:category) -%>
+		<%- for category, object_filters in Participant.object_filters.group_by(&:category) -%>
 	
 		<li class="category <%= "closed" unless category.to_s.starts_with?("_") %>" data-category="<%= category %>">
 			<h4><%= Participant::FILTER_CATEGORIES[category.to_s.to_sym] || "Other" %></h4>

--- a/app/views/participants/_filter_results.html.erb
+++ b/app/views/participants/_filter_results.html.erb
@@ -1,7 +1,17 @@
 <%- if @participant.respond_to?(:passes_filter?) -%>
-	<ul class="filter-results" id="filter_results_container">
-		<%- for object_filter in Participant.object_filters -%>
-			<%= content_tag :li, h(object_filter.title), :class => (@participant.passes_filter?(object_filter) ? "pass" : "fail") if object_filter.display_for?(@participant) %>
-		<% end %>
-	</ul>
+<ul class="filter-results" id="filter_results_container">
+				
+	<%- for category, object_filters in Participant.object_filters.group_by(&:category) -%>
+	<li class="category" data-category="<%= category %>">
+		<h3><%= Participant::FILTER_CATEGORIES[category.to_s.to_sym] || "Other" %></h3>
+
+		<ul>				
+			<%- for object_filter in object_filters -%>	
+				<%= content_tag :li, h(object_filter.title), :class => (@participant.passes_filter?(object_filter) ? "pass" : "fail") if object_filter.display_for?(@participant) %>
+			<% end %>
+		</ul>
+	</li>
+	<% end %>
+	
+</ul>
 <% end %>

--- a/app/views/participants/_participant_groups_sidebar.html.erb
+++ b/app/views/participants/_participant_groups_sidebar.html.erb
@@ -1,0 +1,12 @@
+	<h3>Groups</h3>
+	<ul class="quick_nav" style="margin-top: 0">
+		<%- for participant_group in @participant_groups -%>
+			<li id="participant_group_dropzone_<%= participant_group.id %>">
+				<%= link_to participant_group.try(:title), participant_group_path(participant_group), :class => 'redirect-link' %>
+			</li>
+			<%#= TODO drop_receiving_element "participant_group_dropzone_#{participant_group.id}",
+			 							:url => add_to_group_participants_path(:participant_group_id => participant_group.id),
+										:accept => 'participant',
+										:hoverclass => 'dropzone' %>
+		<% end -%>
+	</ul>

--- a/app/views/participants/_sidebar.html.erb
+++ b/app/views/participants/_sidebar.html.erb
@@ -31,9 +31,7 @@ placeholder_text <<  "all #{Customer.participants_label}" if !@grad_year || !@hi
 	
 <% if controller.action_name != 'show' %>
 
-	<div id="export_actions">
-		<%= render "export_actions" %>
-	</div>
+	<%= content_tag :div, render("export_actions"), :id => "export_actions" %>
 
 	<%- if @high_school %>
 		<form>
@@ -50,45 +48,9 @@ placeholder_text <<  "all #{Customer.participants_label}" if !@grad_year || !@hi
 			</p>
 	<% end %>
 	
-	<%= render :partial => "bulk_actions" %>
-	
-	<%- unless @participants.respond_to?(:current_page) -%>
-	<h3>Filters
-		<%= link_to_function "show all", "clearAllFilters()", :class => "right small" %></h3>
-
-		<ul class="filters">
-		<% for object_filter in Participant.object_filters %>
-			<li id="filter_li_<%= object_filter.id.to_s %>">
-			
-				<% 
-			    dom_id = "filter_#{object_filter.id.to_s}_true"
-			    check_box_str = check_box_tag dom_id, true, false, 
-									:class => "#{object_filter.id.to_s}_filter_checkbox filter_checkbox", 
-									"data-target-filter-id" => object_filter.id.to_s
-				record_count_str = "<small id='record_count_#{object_filter.id}'>&nbsp;</small>"
-				%>
-				<%= label_tag(dom_id, raw("#{check_box_str}#{record_count_str}<span>#{object_filter.opposite_title}</span>")) %>
-			
-			</li>
-		
-		<% end -%>
-		</ul>
-	<% end %>
-		
-	<%- if @participant_groups && !@participant_groups.empty? -%>
-	<h3>Groups</h3>
-	<ul class="quick_nav" style="margin-top: 0">
-		<%- for participant_group in @participant_groups -%>
-			<li id="participant_group_dropzone_<%= participant_group.id %>">
-				<%= link_to participant_group.try(:title), participant_group_path(participant_group), :class => 'redirect-link' %>
-			</li>
-			<%#= TODO drop_receiving_element "participant_group_dropzone_#{participant_group.id}",
-			 							:url => add_to_group_participants_path(:participant_group_id => participant_group.id),
-										:accept => 'participant',
-										:hoverclass => 'dropzone' %>
-		<% end -%>
-	</ul>
-	<% end -%>
+	<%= render "bulk_actions" %>
+	<%= render "filter_controls" unless @participants.respond_to?(:current_page) %>		
+	<%= render "participant_groups_sidebar" if @participant_groups && !@participant_groups.empty? %>
 			
 <% end -%>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,11 @@ Dreamsis::Application.routes.draw do
   # Top-level or Customer-level Objects
   # ---------------------------------------
   resources :customers
-  resources :object_filters
+  resources :object_filters do
+    collection do
+      post :sort
+    end
+  end
   resources :terms do
     collection do
       match :check_export_status

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,11 +6,7 @@ Dreamsis::Application.routes.draw do
   # Top-level or Customer-level Objects
   # ---------------------------------------
   resources :customers
-  resources :object_filters do
-    member do
-      post :formatted_criteria
-    end
-  end
+  resources :object_filters
   resources :terms do
     collection do
       match :check_export_status

--- a/db/migrate/20150609023343_add_category_to_object_filter.rb
+++ b/db/migrate/20150609023343_add_category_to_object_filter.rb
@@ -1,0 +1,5 @@
+class AddCategoryToObjectFilter < ActiveRecord::Migration
+  def change
+    add_column :object_filters, :category, :string
+  end
+end

--- a/db/migrate/20150723045103_add_position_to_object_filter.rb
+++ b/db/migrate/20150723045103_add_position_to_object_filter.rb
@@ -1,0 +1,5 @@
+class AddPositionToObjectFilter < ActiveRecord::Migration
+  def change
+    add_column :object_filters, :position, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150605230416) do
+ActiveRecord::Schema.define(:version => 20150609023343) do
 
   create_table "activity_logs", :force => true do |t|
     t.date     "start_date"
@@ -511,6 +511,7 @@ ActiveRecord::Schema.define(:version => 20150605230416) do
     t.integer  "earliest_grade_level_level"
     t.integer  "latest_grade_level_level"
     t.integer  "customer_id"
+    t.string   "category"
   end
 
   add_index "object_filters", ["customer_id"], :name => "index_object_filters_on_customer_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150609023343) do
+ActiveRecord::Schema.define(:version => 20150723045103) do
 
   create_table "activity_logs", :force => true do |t|
     t.date     "start_date"
@@ -512,6 +512,7 @@ ActiveRecord::Schema.define(:version => 20150609023343) do
     t.integer  "latest_grade_level_level"
     t.integer  "customer_id"
     t.string   "category"
+    t.integer  "position"
   end
 
   add_index "object_filters", ["customer_id"], :name => "index_object_filters_on_customer_id"


### PR DESCRIPTION
Previously stat filters were only displayed in a single list. This update allows organizations to assign filters to categories, which then display in the sidebar for easier readability and use. These categories expand and collapse when clicked, and they auto-expand in cases where a saved filter set is loaded from the window URL hash, setting the stage for "default" filter conditions (although this is not yet implemented).