### PR TITLE
Add customer-specific form text

### DIFF
--- a/app/assets/stylesheets/dreamsis.css.erb
+++ b/app/assets/stylesheets/dreamsis.css.erb
@@ -2811,6 +2811,12 @@ form.formtastic > fieldset > ol > li > label {
 	padding-right: 3%;
 }
 
+.formtastic .label .button.help-text {
+  display: inline-block;
+  float: none;
+  margin-left: 0.5em;
+}
+
 /*input.currency:before {
   content: "$ ";
   float: left;

--- a/app/assets/stylesheets/dreamsis.css.erb
+++ b/app/assets/stylesheets/dreamsis.css.erb
@@ -2807,7 +2807,7 @@ form.formtastic fieldset fieldset {
 }
 
 form.formtastic > fieldset > ol > li > label {
-	width: 22%;
+/*  width: 22%;*/
 	padding-right: 3%;
 }
 

--- a/app/assets/stylesheets/my_formtastic_changes.css
+++ b/app/assets/stylesheets/my_formtastic_changes.css
@@ -6,6 +6,14 @@
   width: 22%;
 }
 
+.formtastic .input .input .label {
+  width: 100%;
+}
+
+.formtastic .number input {
+  width: 5em;
+}
+
 input[type=file] {
   border: none !important;
   background: none !important;

--- a/app/models/help_text.rb
+++ b/app/models/help_text.rb
@@ -1,5 +1,5 @@
 class HelpText < ActiveRecord::Base
-  attr_accessible :attribute_name, :instructions, :object_class, :title
+  attr_accessible :attribute_name, :instructions, :object_class, :title, :hint
   validates_uniqueness_of :attribute_name, :scope => [:object_class]
   
   def self.for(object_class, attribute_name)

--- a/app/models/help_text.rb
+++ b/app/models/help_text.rb
@@ -1,0 +1,12 @@
+class HelpText < ActiveRecord::Base
+  attr_accessible :attribute_name, :instructions, :object_class, :title
+  validates_uniqueness_of :attribute_name, :scope => [:object_class]
+  
+  def self.for(object_class, attribute_name)
+    HelpText.for_object_class(object_class.to_s)[attribute_name.to_s]
+  end
+  
+  def self.for_object_class(object_class)
+    Hash[HelpText.where(object_class: object_class.to_s).map{ |ht| [ht.attribute_name.to_s, ht] }]
+  end
+end

--- a/app/views/participants/fields/_background.html.erb
+++ b/app/views/participants/fields/_background.html.erb
@@ -20,7 +20,7 @@
 				].flatten.uniq %>
 
 	<%= f.input :postsecondary_plan, :as => :select, 
-				:hint => "What is the student's plan after high school? This field likely won't be filled in until close to high school graduation time." + ("<br />" + content_tag(:span, "Note: Changing the postsecondary plan will unset the college that #{h(f.object.firstname)} is planning to attend.", :class => "weak error-message") unless f.object.college_attending_id.nil?).to_s, 
+				:hint => "What is the student's plan after high school? This field likely won't be filled in until close to high school graduation time.".html_safe + ("<br />".html_safe + content_tag(:span, h("Note: Changing the postsecondary plan will unset the college that #{h(f.object.firstname)} is planning to attend."), :class => "weak error-message") unless f.object.college_attending_id.nil?).to_s, 
 				:collection => [
 					h(f.object.postsecondary_plan),
 					Institution::ICLEVEL_DESCRIPTIONS.values,

--- a/app/views/participants/fields/_family_history.html.erb
+++ b/app/views/participants/fields/_family_history.html.erb
@@ -1,13 +1,9 @@
 <%= f.inputs :name => "Family History Information" do -%>
 
+    <%= f.input :first_generation, :as => :select, :label => "Did parents graduate from college?", :collection => { "No (student is first generation to college)" => true, "Yes (student is NOT first generation to college)" => false } %>
+	<%= f.input :family_members_who_went_to_college, :input_html => { :size => "90%" } %>
+	<%= f.input :family_members_graduated, :label => "Did any of them graduate?" %>    
 	
-    <%= f.inputs :name => "First-generation college student", :class => "inline" do -%>
-        <%= f.input :first_generation, :label => "First in immediate family to go to college/university" %>
-    	<%= f.input :family_members_who_went_to_college %>
-    	<%= f.input :family_members_graduated, :label => "Did any of them graduate?" %>    
-    <% end %>
-    
-
 	<%= f.inputs :name => "Attended school outside USA", :class => "inline" do -%>
 		<%= f.input :attended_school_outside_usa, :label => "Yes" %>
 		<%= f.input :countries_attended_school_outside_usa, :label => "In what countries?" %>

--- a/config/initializers/formtastic.rb
+++ b/config/initializers/formtastic.rb
@@ -74,3 +74,38 @@ Formtastic::FormBuilder.use_required_attribute = true
 # this to false. Doing so will add a `novalidate` attribute to the `<form>` tag.
 # See http://diveintohtml5.org/forms.html#validation for more info.
 Formtastic::FormBuilder.perform_browser_validations = true
+
+
+module Formtastic
+  module Inputs
+    module Base
+      module Hints
+
+        def hint_html
+          output = "".html_safe
+          
+          if help_text = HelpText.for(object_name.classify, method)
+            output << template.content_tag(
+            :div,
+            template.content_tag(
+              :span, Formtastic::Util.html_safe(help_text.try(:instructions))
+            ),
+            :class => "button icon info icon-only help-text"
+            )
+          end
+          
+          if hint?
+            output << template.content_tag(
+            :p, 
+            Formtastic::Util.html_safe(hint_text), 
+            :class => builder.default_hint_class
+            )
+          end
+          
+          return output
+        end
+        
+      end      
+    end
+  end
+end

--- a/config/initializers/formtastic.rb
+++ b/config/initializers/formtastic.rb
@@ -75,37 +75,4 @@ Formtastic::FormBuilder.use_required_attribute = true
 # See http://diveintohtml5.org/forms.html#validation for more info.
 Formtastic::FormBuilder.perform_browser_validations = true
 
-
-module Formtastic
-  module Inputs
-    module Base
-      module Hints
-
-        def hint_html
-          output = "".html_safe
-          
-          if help_text = HelpText.for(object_name.classify, method)
-            output << template.content_tag(
-            :div,
-            template.content_tag(
-              :span, Formtastic::Util.html_safe(help_text.try(:instructions))
-            ),
-            :class => "button icon info icon-only help-text"
-            )
-          end
-          
-          if hint?
-            output << template.content_tag(
-            :p, 
-            Formtastic::Util.html_safe(hint_text), 
-            :class => builder.default_hint_class
-            )
-          end
-          
-          return output
-        end
-        
-      end      
-    end
-  end
-end
+require "#{Rails.root}/lib/formtastic_customizations.rb"

--- a/db/migrate/20150903010703_create_help_texts.rb
+++ b/db/migrate/20150903010703_create_help_texts.rb
@@ -1,0 +1,12 @@
+class CreateHelpTexts < ActiveRecord::Migration
+  def change
+    create_table :help_texts do |t|
+      t.string :object_class
+      t.string :attribute_name
+      t.string :title
+      t.text :instructions
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20150904055454_add_hint_to_help_text.rb
+++ b/db/migrate/20150904055454_add_hint_to_help_text.rb
@@ -1,0 +1,5 @@
+class AddHintToHelpText < ActiveRecord::Migration
+  def change
+    add_column :help_texts, :hint, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150723045103) do
+ActiveRecord::Schema.define(:version => 20150903010703) do
 
   create_table "activity_logs", :force => true do |t|
     t.date     "start_date"
@@ -290,6 +290,15 @@ ActiveRecord::Schema.define(:version => 20150723045103) do
     t.datetime "updated_at"
   end
 
+  create_table "help_texts", :force => true do |t|
+    t.string   "object_class"
+    t.string   "attribute_name"
+    t.string   "title"
+    t.text     "instructions"
+    t.datetime "created_at",     :null => false
+    t.datetime "updated_at",     :null => false
+  end
+
   create_table "how_did_you_hear_options", :force => true do |t|
     t.string   "name"
     t.boolean  "show_for_participants"
@@ -471,6 +480,16 @@ ActiveRecord::Schema.define(:version => 20150723045103) do
   end
 
   add_index "mentor_terms", ["customer_id"], :name => "index_mentor_terms_on_customer_id"
+
+  create_table "multitenant_proxies", :force => true do |t|
+    t.string   "proxyable_type"
+    t.integer  "proxyable_id"
+    t.string   "role"
+    t.integer  "other_customer_id"
+    t.integer  "other_id"
+    t.datetime "created_at",        :null => false
+    t.datetime "updated_at",        :null => false
+  end
 
   create_table "notes", :force => true do |t|
     t.text     "note"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150903010703) do
+ActiveRecord::Schema.define(:version => 20150904055454) do
 
   create_table "activity_logs", :force => true do |t|
     t.date     "start_date"
@@ -297,6 +297,7 @@ ActiveRecord::Schema.define(:version => 20150903010703) do
     t.text     "instructions"
     t.datetime "created_at",     :null => false
     t.datetime "updated_at",     :null => false
+    t.text     "hint"
   end
 
   create_table "how_did_you_hear_options", :force => true do |t|

--- a/lib/formtastic_customizations.rb
+++ b/lib/formtastic_customizations.rb
@@ -1,0 +1,57 @@
+module Formtastic
+  module Inputs
+    module Base
+      module Hints
+
+        def hint_html
+          output = "".html_safe
+          
+          if hint?
+            output << template.content_tag(
+            :p, 
+            Formtastic::Util.html_safe(hint_text), 
+            :class => builder.default_hint_class
+            )
+          end
+          
+          # Add customer-specific help text
+          if help_text = HelpText.for(object_name.classify, method)
+            output << template.content_tag(
+            :p,
+            Formtastic::Util.html_safe(help_text.try(:hint)),
+            :class => "#{builder.default_hint_class} customized"
+            ) unless help_text.try(:hint).blank?
+          end
+          
+          return output
+        end
+        
+      end
+      
+      module Labelling
+        
+        def label_html
+          if render_label?
+            help_text = HelpText.for(object_name.classify, method)
+            custom_label_text = Formtastic::Util.html_safe(help_text.try(:title)) || label_text
+            
+            # Add customer-specific instructions text
+            custom_label_text << template.content_tag(
+              :div,
+              template.content_tag(
+                :span, Formtastic::Util.html_safe(help_text.try(:instructions))
+              ),
+              :class => "button icon info icon-only help-text"
+            ) unless help_text.try(:instructions).blank?
+            
+            builder.label(input_name, custom_label_text, label_html_options)
+          else
+            "".html_safe
+          end
+        end
+        
+      end
+      
+    end
+  end
+end

--- a/test/fixtures/help_texts.yml
+++ b/test/fixtures/help_texts.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/Fixtures.html
+
+one:
+  object_class: MyString
+  attribute_name: MyString
+  title: MyString
+  instructions: MyText
+
+two:
+  object_class: MyString
+  attribute_name: MyString
+  title: MyString
+  instructions: MyText

--- a/test/unit/help_text_test.rb
+++ b/test/unit/help_text_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class HelpTextTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Allows customers to customize labels, hints, and instructions for any form attribute, and patches Formtastic to automatically use these when available.