### PR TITLE
Adds inquiry type customization to NSC requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ pid/sidekiq.pid
 public/images/icons/tango/.DS_Store
 
 public/images/icons/tango/12x12/.DS_Store
+
+ey-ssh.sh

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -60,6 +60,12 @@ class Customer < ActiveRecord::Base
     return_integer ? raw : raw.to_s.rjust(6, "0")
   end
   
+  # If the Customer defines a different name for use with ClearinghouseRequests, return that. 
+  # Otherwise, just return the name.
+  def name_for_clearinghouse 
+    clearinghouse_customer_name || name
+  end
+  
   # Returns true if +term_system+ is +Quarters+.
   def use_quarters?
     term_system == "Quarters"

--- a/app/views/clearinghouse_requests/_clearinghouse_request.html.erb
+++ b/app/views/clearinghouse_requests/_clearinghouse_request.html.erb
@@ -6,6 +6,5 @@
 	<td class="centered number"><%= clearinghouse_request.number_of_records_submitted %></td>
 	<td class="centered number"><%= clearinghouse_request.number_of_records_returned %></td>
     <td class="functions"><%= link_to 'Show', clearinghouse_request %></td>
-    <td class="functions"><%= link_to 'Edit', edit_clearinghouse_request_path(clearinghouse_request) unless clearinghouse_request.submitted? %></td>
     <td class="functions"><%= link_to 'Destroy', clearinghouse_request, :confirm => 'Are you sure?', :method => :delete unless clearinghouse_request.submitted? %></td>
 </tr>

--- a/app/views/clearinghouse_requests/_fields.html.erb
+++ b/app/views/clearinghouse_requests/_fields.html.erb
@@ -14,12 +14,21 @@
 				Class of <%= cohort %>
 			</label>
 		</li>
-	<% end %>	
-<% end %>	
+	<% end %>
+	<p>&nbsp;</p>
+
+	<%= f.inputs "Exclusions", :class => "inline" do %>
+		<%= f.input :exclude_inactive, :as => :boolean, :label => "Exclude inactive #{Customer.participants_label}" %>
+		<%= f.input :exclude_not_target, :as => :boolean, :label => "Exclude #{Customer.not_target_label} #{Customer.participants_label}" %>
+	<% end %>
+<% end %>
 
 <%= f.inputs :name => "Account Settings" do -%>
 	<%= f.input :plain_ftp_password, 
 				:label => "FTP Password", 
 				:hint => "You must have an FTP account assigned. The password you enter here is encrypted
 				 		 and only used for the life of this specific request." %>
+						 
+	<%= f.input :inquiry_type, 
+				:collection => ClearinghouseRequest::InquiryTypes.invert %>
 <% end %>

--- a/app/views/clearinghouse_requests/show.html.erb
+++ b/app/views/clearinghouse_requests/show.html.erb
@@ -5,6 +5,9 @@
 
 <dl class="inline-definitions">
 	
+	<dt>Inquiry Type</dt>
+	<dd><%= @clearinghouse_request.inquiry_type_description %></dd>
+	
 	<dt>Created</dt>
 	<dd>
 		<%= @clearinghouse_request.created_at.to_s(:date_with_full_month) %>
@@ -14,6 +17,12 @@
         <%- if missing_count > 0 -%>
             <span class="light">(<%= pluralize missing_count, "record" %> no longer found)</span>
         <% end %>
+		
+		<ul>
+			<%- for criterion in @clearinghouse_request.selection_criteria || [] -%>
+				<%= content_tag :li, criterion %>
+			<% end %>
+		</ul>
 
 		<%- unless @clearinghouse_request.submitted? -%>
 			<p>
@@ -37,7 +46,7 @@
 				<p>
 					<br /><%= link_to "Retrieve results now", retrieve_clearinghouse_request_path(@clearinghouse_request), :method => :post, :class => "download button" if @clearinghouse_request.retrievable? %>
 					<%= separator if @clearinghouse_request.retrievable? %>
-					<%= link_to_function "Upload results file", "$('#upload_form').show()", :class => "save button" %>
+					<%= link_to_function "Upload results file", "$('#upload_form').show()", :class => "save button" unless @clearinghouse_request.closed? %>
 				</p>
 				
 				<%= form_tag upload_clearinghouse_request_path(@clearinghouse_request), :id => 'upload_form', :style => "display:none", :multipart => true do |f| -%>
@@ -84,7 +93,7 @@
 		</ul>
 	</dd>
 	
-	<%- if @clearinghouse_request.submitted? && !@clearinghouse_request.retrieved? -%>
+	<%- if @clearinghouse_request.submitted? && @clearinghouse_request.retrievable? -%>
 		<dt>Processing Log</dt>
 		<dd>
 			<code id="processing_log_container"><em>Loading...</em></code>
@@ -95,9 +104,13 @@
 
 <div id="sidebar">
 	<p><%= link_to "Back to requests", clearinghouse_requests_path, :class => "back button" %></p>
+	
+	<%- unless @clearinghouse_request.closed? -%>
+		<p><%= link_to "Close this request", [:close, @clearinghouse_request], :class => "cancel button", :method => :post, :confirm => "Are you sure you want to close out this request?" %></p>
+	<% end %>
 </div>
 
 <%= javascript_tag "$( function() {
 	$.ajax('#{refresh_status_clearinghouse_request_path(@clearinghouse_request, :current_status => @clearinghouse_request.status)}', 
 		{ dataType: 'script' })
-	})" if @clearinghouse_request.submitted? && !@clearinghouse_request.retrieved? %>
+	})" if @clearinghouse_request.submitted? && @clearinghouse_request.retrievable? %>

--- a/app/views/customers/_fields.html.erb
+++ b/app/views/customers/_fields.html.erb
@@ -53,10 +53,15 @@
 	<p>If you have a contract with the National Student Clearinghouse, enter your account information here and 
 		DreamSIS can perform automatic queries about your participants.</p>
 		<%= f.input :clearinghouse_customer_number, 
-					:label => "Customer Number", 
+					:label => "Customer/School Number", 
 					:hint => "Your customer number (or account number) should be six digits. If your customer number starts with a zero,
-                             DreamSIS will automatically add the leading zeros.",
+                             DreamSIS will automatically add the leading zeros. Higher education institution accounts should use their
+							 school code.",
 					:input_html => { :size => 6 } %>
+		<%= f.input :clearinghouse_customer_name, :label => "Customer Name",
+			 		:hint => "In most cases, this is the same as your organization name, but if your NSC account is setup under a
+							  different name, enter it here." %>
+		<%= f.input :clearinghouse_entity_type, :label => "Entity Type", :collection => { "S - Direct-service Organization" => "S", "I - Higher-education Institution" => "I" } %>
 		<%= f.input :clearinghouse_contract_start_date, 
 					:label => "Contract Start Date", 
 					:hint => "Enter the start date of the current contract. You'll need to update this 

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -103,7 +103,7 @@
 				<ul>
 					<% if @current_user.admin? && Customer.current_customer %>
 						<li class="settings">
-							<%= link_to "#{Customer.current_customer.name} Settings", Customer.current_customer %>
+							<%= link_to "#{Customer.current_customer.name} Settings", [:edit, Customer.current_customer] %>
 						</li>
 					<% end %>
 					<li class="locations"><%= link_to raw("Locations &amp; Colleges"), locations_url %></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -158,6 +158,7 @@ Dreamsis::Application.routes.draw do
       post :upload
       get :refresh_status
       get :results
+      post :close
     end
   end
   match '/my/mentees' => 'participants#mentor', :as => :my_participants, :mentor_id => 'me'

--- a/db/migrate/20150924012848_add_clearinghouse_inquiry_types_to_customer.rb
+++ b/db/migrate/20150924012848_add_clearinghouse_inquiry_types_to_customer.rb
@@ -1,0 +1,7 @@
+class AddClearinghouseInquiryTypesToCustomer < ActiveRecord::Migration
+  def change
+    add_column :customers, :clearinghouse_customer_name, :string
+    add_column :customers, :clearinghouse_entity_type, :string
+    add_column :clearinghouse_requests, :inquiry_type, :string
+  end
+end

--- a/db/migrate/20150924023117_add_selection_criteria_to_clearinghouse_request.rb
+++ b/db/migrate/20150924023117_add_selection_criteria_to_clearinghouse_request.rb
@@ -1,0 +1,5 @@
+class AddSelectionCriteriaToClearinghouseRequest < ActiveRecord::Migration
+  def change
+    add_column :clearinghouse_requests, :selection_criteria, :text
+  end
+end

--- a/db/migrate/20150924024227_add_closed_date_to_clearinghouse_request.rb
+++ b/db/migrate/20150924024227_add_closed_date_to_clearinghouse_request.rb
@@ -1,0 +1,5 @@
+class AddClosedDateToClearinghouseRequest < ActiveRecord::Migration
+  def change
+    add_column :clearinghouse_requests, :closed_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150904055454) do
+ActiveRecord::Schema.define(:version => 20150924024227) do
 
   create_table "activity_logs", :force => true do |t|
     t.date     "start_date"
@@ -55,6 +55,9 @@ ActiveRecord::Schema.define(:version => 20150904055454) do
     t.datetime "updated_at"
     t.string   "detail_report_filename"
     t.text     "filenames"
+    t.string   "inquiry_type"
+    t.text     "selection_criteria"
+    t.datetime "closed_at"
   end
 
   create_table "college_applications", :force => true do |t|
@@ -106,6 +109,8 @@ ActiveRecord::Schema.define(:version => 20150904055454) do
     t.boolean  "send_driver_form_emails"
     t.boolean  "display_nicknames_by_default"
     t.integer  "driver_training_validity_length"
+    t.string   "clearinghouse_customer_name"
+    t.string   "clearinghouse_entity_type"
   end
 
   create_table "degrees", :force => true do |t|

--- a/lib/national_student_clearinghouse.rb
+++ b/lib/national_student_clearinghouse.rb
@@ -143,10 +143,10 @@ class NationalStudentClearinghouse
       "H1",
       @customer.clearinghouse_customer_number.to_s.rjust(6),
       "00",
-      @customer.name.to_s[0..39],
+      @customer.name_for_clearinghouse.to_s[0..39],
       Time.now.to_date.to_s(:number),
-      "DA",
-      "S",
+      (request.inquiry_type || "DA"),
+      (@customer.clearinghouse_entity_type || "S"),
       "", "", "", "", ""
     ]
     strip_illegal_characters(elements.join("\t"))
@@ -197,7 +197,7 @@ class NationalStudentClearinghouse
       p.birthdate.to_s(:number),
       "#{p.grad_year}0901",
       "",
-      "",
+      (@customer.clearinghouse_entity_type == "I" ? @customer.clearinghouse_customer_number.to_s.rjust(6) : ""),
       "00",
       p.id.to_s
     ]


### PR DESCRIPTION
Allows the customer to customize many aspects of the NSC requests:

* entity type, which can now can accommodate higher-ed accounts without manual post-processing
* inquiry type, especially “consent-based” query which has better performance
* custom account name, in the case where the NSC account name doesn’t match the DreamSIS customer name
* exclude inactive or non-target participants from the request to reduce unnecessary queries

Also adds the ability to formally “close” a request, and better display/tracking of the selection criteria used to set up the request. Previously, there was no way to know which cohorts had been selected in a previous request, other than inferring from the record count.