### PR TITLE
Implement session sweeping

### DIFF
--- a/app/models/multitenant_proxy.rb
+++ b/app/models/multitenant_proxy.rb
@@ -36,7 +36,7 @@ class MultitenantProxy < ActiveRecord::Base
     raise Exception.new("Slave object already exists") if other_object
     raise Exception.new("Cannot create slave object until current object is valid") unless valid? && persisted?
 
-    Rollbar.warning "Sidekiq note ready" unless Report.sidekiq_ready?
+    Rollbar.warning "Sidekiq not ready" unless Report.sidekiq_ready?
     MultitenantProxyWorker.perform_async(Customer.tenant_name, self.id)
   end
   
@@ -53,7 +53,7 @@ class MultitenantProxy < ActiveRecord::Base
   # an object. If this is a Master object, then we update the attributes on the Slave object.
   def update_slave
     return false unless master?
-    Rollbar.warning "Sidekiq note ready" unless Report.sidekiq_ready?
+    Rollbar.warning "Sidekiq not ready" unless Report.sidekiq_ready?
     MultitenantProxyWorker.perform_async(Customer.tenant_name, self.id)
   end
   

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -1,0 +1,8 @@
+class Session < ActiveRecord::Base
+  def self.sweep!(time = 12.hours, max = 3.days)
+    time = time.split.inject { |count, unit| count.to_i.send(unit) } if time.is_a?(String)
+    max = max.split.inject { |count, unit| count.to_i.send(unit) } if max.is_a?(String)
+    
+    delete_all "updated_at < '#{time.ago.to_s(:db)}' OR created_at < '#{max.ago.to_s(:db)}'"
+  end
+end

--- a/lib/tasks/sessions.rake
+++ b/lib/tasks/sessions.rake
@@ -1,0 +1,10 @@
+namespace :sessions do 
+  
+  desc "Delete sessions that are older than a specified age"
+  task :sweep => :environment do
+    Rails.logger = Logger.new(STDOUT)
+    STDOUT.sync = true
+    puts "Deleted #{Session.sweep!} aged sessions."
+  end
+  
+end


### PR DESCRIPTION
Provides a method and rake task for automatically clearing out sessions that are older than a few days, or inactive for more than 12 hours. Use `rake sessions:sweep` to trigger the sweep.