### PR TITLE
Remove LOWER() from search queries

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -97,7 +97,7 @@ class EventsController < ApplicationController
   def auto_complete_model_for_person_fullname
     @people = Person.find(
       :all,
-      :conditions => ['LOWER(lastname) LIKE :q', 
+      :conditions => ['lastname LIKE :q', 
                         {:q => "%#{params[:person][:fullname].downcase}%"}],
       :limit => 10
     )

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -109,7 +109,7 @@ class LocationsController < ApplicationController
   end
 
   def auto_complete_for_location_name
-    @locations = Location.find(:all, :conditions => ["LOWER(name) LIKE ?", "%#{params[:term].to_s.downcase}%"])
+    @locations = Location.find(:all, :conditions => ["name LIKE ?", "%#{params[:term].to_s.downcase}%"])
     render :json => @locations.map { |result|
       {
         :id => result.id, 

--- a/app/controllers/mentors_controller.rb
+++ b/app/controllers/mentors_controller.rb
@@ -146,10 +146,10 @@ class MentorsController < ApplicationController
   
   def auto_complete_for_mentor_fullname
     @mentors = Mentor.find(:all,
-                          :conditions => ["LOWER(firstname) LIKE :fullname
-                                            OR LOWER(lastname) LIKE :fullname
-                                            OR LOWER(display_name) LIKE :fullname
-                                            OR LOWER(uw_net_id) LIKE :fullname",
+                          :conditions => ["firstname LIKE :fullname
+                                            OR lastname LIKE :fullname
+                                            OR display_name LIKE :fullname
+                                            OR uw_net_id LIKE :fullname",
                                           {:fullname => "%#{params[:term].downcase}%"}])
 
     render :json => @mentors.map { |mentor| 

--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -366,7 +366,7 @@ class ParticipantsController < ApplicationController
     if params[:term].to_i != 0
       @participants = [ Participant.find(params[:term].to_i) ]
     else      
-      conditions = ["(LOWER(firstname) LIKE :fullname OR LOWER(lastname) LIKE :fullname)"]
+      conditions = ["(firstname LIKE :fullname OR lastname LIKE :fullname)"]
       conditions << "high_school_id = :high_school_id" if params[:high_school_id]
       conditions << "grad_year = :grad_year" if params[:grad_year]
     

--- a/app/controllers/scholarship_applications_controller.rb
+++ b/app/controllers/scholarship_applications_controller.rb
@@ -88,7 +88,7 @@ class ScholarshipApplicationsController < ParticipantsController
 
   def auto_complete_for_scholarship_application_title
     @scholarships = Scholarship.find(:all, 
-                      :conditions => ["LOWER(title) LIKE ?", '%' + params[:scholarship_application][:title].downcase + '%'],
+                      :conditions => ["title LIKE ?", '%' + params[:scholarship_application][:title].downcase + '%'],
                       :limit => 10)
     render :json => @scholarships.map { |result| 
       {

--- a/app/controllers/scholarships_controller.rb
+++ b/app/controllers/scholarships_controller.rb
@@ -46,7 +46,7 @@ class ScholarshipsController < ResourceController
 		if term.is_integer?
 			@scholarships = [Scholarship.find(term)]
 		else
-	    @scholarships = Scholarship.find(:all, :conditions => ["LOWER(title) LIKE ?", "%#{term.to_s.downcase}%"], :limit => 20)
+	    @scholarships = Scholarship.find(:all, :conditions => ["title LIKE ?", "%#{term.to_s.downcase}%"], :limit => 20)
 		end
     render :json => @scholarships.map { |result| 
       {

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -114,11 +114,11 @@ class UsersController < ApplicationController
   def auto_complete_for_user_login
     @users = User.find(:all, 
                           :joins => [:person],
-                          :conditions => ["LOWER(login) LIKE :login
-                                              OR LOWER(people.firstname) LIKE :fullname 
-                                              OR LOWER(people.lastname) LIKE :fullname
-                                              OR LOWER(people.display_name) LIKE :fullname
-                                              OR LOWER(people.uw_net_id) LIKE :fullname", 
+                          :conditions => ["login LIKE :login
+                                              OR people.firstname LIKE :fullname 
+                                              OR people.lastname LIKE :fullname
+                                              OR people.display_name LIKE :fullname
+                                              OR people.uw_net_id LIKE :fullname", 
                                           {:login => "%#{params[:user][:login].downcase}%",
                                           :fullname => "%#{params[:user][:login].downcase}%"}])                                          
     respond_to do |format|

--- a/db/migrate/20151114002442_add_index_to_person_nickname.rb
+++ b/db/migrate/20151114002442_add_index_to_person_nickname.rb
@@ -1,0 +1,7 @@
+class AddIndexToPersonNickname < ActiveRecord::Migration
+  def change
+    add_index :people, :nickname
+    add_index :people, :middlename
+    add_index :people, :type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20151112183412) do
+ActiveRecord::Schema.define(:version => 20151114002442) do
 
   create_table "activity_logs", :force => true do |t|
     t.date     "start_date"
@@ -769,6 +769,9 @@ ActiveRecord::Schema.define(:version => 20151112183412) do
   add_index "people", ["firstname"], :name => "index_people_on_firstname"
   add_index "people", ["grad_year"], :name => "index_people_on_grad_year"
   add_index "people", ["lastname"], :name => "index_people_on_lastname"
+  add_index "people", ["middlename"], :name => "index_people_on_middlename"
+  add_index "people", ["nickname"], :name => "index_people_on_nickname"
+  add_index "people", ["type"], :name => "index_people_on_type"
   add_index "people", ["uw_net_id"], :name => "index_people_on_uw_net_id"
 
   create_table "people_fafsas", :force => true do |t|


### PR DESCRIPTION
Our tables are set to case-insensitive so LOWER() is unnecessary and
prevents mysql from taking advantage of index search.