### PR TITLE
Adds dynamic tagging functionality system-wide

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,8 @@ gem 'coderay', :require =>  'coderay'
 gem 'acts_as_list'
 gem 'fabrication'
 gem 'faker'
+gem 'acts-as-taggable-on', '~> 3.4'
+gem 'select2-rails'
 
 group :production do
   gem 'mysql2', '~> 0.3.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,8 @@ GEM
     activesupport (3.2.19)
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
+    acts-as-taggable-on (3.5.0)
+      activerecord (>= 3.2, < 5)
     acts_as_list (0.7.2)
       activerecord (>= 3.0)
     acts_as_xlsx (1.0.6)
@@ -260,6 +262,8 @@ GEM
       railties (~> 3.2.0)
       sass (>= 3.1.10)
       tilt (~> 1.3)
+    select2-rails (4.0.1.1)
+      thor (~> 0.14)
     sidekiq (3.3.0)
       celluloid (>= 0.16.0)
       connection_pool (>= 2.0.0)
@@ -309,6 +313,7 @@ PLATFORMS
 
 DEPENDENCIES
   RedCloth
+  acts-as-taggable-on (~> 3.4)
   acts_as_list
   acts_as_xlsx
   addressable
@@ -358,6 +363,7 @@ DEPENDENCIES
   rollbar
   rubyzip
   sass-rails
+  select2-rails
   sidekiq
   simple_calendar (~> 1.1.0)
   sqlite3

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -9,6 +9,7 @@
 //= require jquery-ui
 //= require jquery-tablesorter
 //= require autocomplete-rails
+//= require select2-full
 //= require dreamsis.js
 //=  require_tree .
 

--- a/app/assets/javascripts/dreamsis.js
+++ b/app/assets/javascripts/dreamsis.js
@@ -162,6 +162,15 @@ $( function() {
     );
   })
   
+  // Prep the taggable fields
+  $('select.taggable').each(function() {
+      $(this).select2({
+          minimumResultsForSearch: Infinity,
+          placeholder: "Assign tags"
+      });
+  });
+  
+  
   // Enable all tablesorter tables
   registerTableSorters()
   

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -8,6 +8,7 @@
  *= require_self
  *= require jquery-ui
  *= require jquery-tablesorter/theme.dreamsis
+ *= require select2
  *= require dreamsis
  *= require menus
  *= require syntax

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -38,6 +38,8 @@ class Customer < ActiveRecord::Base
   has_many :clearinghouse_requests
   
   serialize :allowable_login_methods
+  
+  acts_as_taggable_on :mentor_term_tags
 
   attr_accessor :validate_clearinghouse_configuration
   

--- a/app/models/mentor_term.rb
+++ b/app/models/mentor_term.rb
@@ -14,6 +14,8 @@ class MentorTerm < ActiveRecord::Base
   after_destroy :update_filter_cache
   # after_create :add_to_group
   
+  acts_as_taggable
+  
   def destroy
     update_attribute :deleted_at, Time.now
     MentorTermGroup.decrement_counter(:mentor_terms_count, mentor_term_group.id)

--- a/app/models/users/user.rb
+++ b/app/models/users/user.rb
@@ -8,6 +8,8 @@ class User < ActiveRecord::Base
   alias_attribute :username, :login
   delegate :email, :participants, :current_locations, :to => :person
   
+  acts_as_tagger
+  
   # Pulls the current user out of Thread.current. We try to avoid this when possible, but sometimes we need 
   # to access the current user in a model (e.g., to check EmailQueue#messages_waiting?).
   def self.current_user

--- a/app/views/customers/_fields.html.erb
+++ b/app/views/customers/_fields.html.erb
@@ -42,6 +42,12 @@
     <%= f.input :paperwork_status_options, :input_html => { :rows => 5 }, :hint => "Specify the options you want to allow for paperwork status choices. Enter one entry per line. By default, the options are 'Not Started', 'In Progress', and 'Complete.'" %>
     <%= f.input :visit_attendance_options, :input_html => { :rows => 5 }, :hint => "Specify the options you want to allow for visit attendance. Enter one entry per line. If nothing is specified here, 'Attended' will appear only as a single checkbox." %>
 	
+	<%= f.input :mentor_term_tag_list,
+			      as: :select,
+				  label: "Mentor Term Tags",
+				  collection: f.object.mentor_term_tag_list,
+			      input_html: { class: 'taggable', multiple: true, style: "width: 50%", "data-tags" => true } %>
+	
 	<%= f.inputs :name => "Activity Log Time Categories", :class => "inline" do %>
 		<%= f.input :activity_log_student_time_categories, :input_html => { :rows => 10}, :label => "Student Time" %>
 		<%= f.input :activity_log_non_student_time_categories, :input_html => { :rows => 10}, :label => "Non-Student Time" %>

--- a/app/views/mentor_term_groups/_mentor_term.html.erb
+++ b/app/views/mentor_term_groups/_mentor_term.html.erb
@@ -13,6 +13,8 @@
 			<%= raw "#{content_tag :span, Customer.lead_Label, :class => 'admin tag'}" if mentor_term.lead? %>
 			<%= raw "#{content_tag :span, "Enrolled", :class => 'green tag'}" unless mentor_term.volunteer? %>
 			<%= raw "#{content_tag :span, "Driver", :class => 'grey tag'}" if mentor_term.driver? || mentor_term.mentor.valid_van_driver? %>
+			
+			<%= safe_join mentor_term.tag_list.collect{ |tag| content_tag(:span, tag, class: 'tag') } %>
 		</div>
 			<% if !mentor_term.mentor.passed_basics? %>
 	  <div><strong><%= mentor_term.mentor.readiness_summary %></strong></div>

--- a/app/views/mentor_term_groups/_photo_tile.html.erb
+++ b/app/views/mentor_term_groups/_photo_tile.html.erb
@@ -1,7 +1,8 @@
 	<li class="photo">
-		<%= "#{content_tag :span, "L", :class => 'admin tag'}" if photo_tile.lead? %>
-		<%= "#{content_tag :span, "V", :class => 'orange tag'}" if photo_tile.volunteer? %>
-		<%= "#{content_tag :span, "D", :class => 'grey tag'}" if photo_tile.driver? %>
+		<%= content_tag(:span, "L", :class => 'admin tag') if photo_tile.lead? %>
+		<%= content_tag(:span, "V", :class => 'orange tag') if photo_tile.volunteer? %>
+		<%= content_tag(:span, "D", :class => 'grey tag') if photo_tile.driver? %>
+		<%= safe_join photo_tile.tag_list.collect{ |tag| content_tag(:span, tag.to_s[0], class: 'tag') } %>
 		
 		<%= image_tag photo_mentor_path(photo_tile.try(:mentor), :size => :default), 
 						:class => 'student_photo', 

--- a/app/views/mentor_terms/_fields.html.erb
+++ b/app/views/mentor_terms/_fields.html.erb
@@ -3,5 +3,15 @@
 	<%= f.input :volunteer if Customer.link_to_uw? %>
 	<%= f.input :driver %>
 	
-	<%= f.input :notes, :input_html => { :rows => 5 } %>
-<% end -%>
+	<%= f.input :tag_list,
+			      as: :select,
+				  label: "Tags",
+				  hint: "These tags will only apply to this person for the current term. 
+				  		Note: The list of tags are defined in your customer settings.",
+				  collection: Customer.mentor_term_tag_list,
+			      input_html: { class: 'taggable', multiple: true, style: "width: 50%" } %>
+<% end -%>				  
+	
+<%= f.inputs "Notes" do %>
+	<%= f.input :notes, :input_html => { :rows => 5 } %>	
+<% end %>

--- a/db/migrate/20160310061846_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20160310061846_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
@@ -1,0 +1,35 @@
+# This migration comes from acts_as_taggable_on_engine (originally 1)
+class ActsAsTaggableOnMigration < ActiveRecord::Migration
+  def self.up
+    # Clear out the old tags tables
+    drop_table :taggings
+    drop_table :tags
+    
+    create_table :tags do |t|
+      t.string :name
+    end
+    
+    create_table :taggings do |t|
+      t.references :tag
+
+      # You should make sure that the column created is
+      # long enough to store the required class names.
+      t.references :taggable, polymorphic: true
+      t.references :tagger, polymorphic: true
+
+      # Limit is created to prevent MySQL error on index
+      # length for MyISAM table type: http://bit.ly/vgW2Ql
+      t.string :context, limit: 128
+
+      t.datetime :created_at
+    end
+
+    add_index :taggings, :tag_id
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+
+  def self.down
+    drop_table :taggings
+    drop_table :tags
+  end
+end

--- a/db/migrate/20160310061847_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20160310061847_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -1,0 +1,20 @@
+# This migration comes from acts_as_taggable_on_engine (originally 2)
+class AddMissingUniqueIndices < ActiveRecord::Migration
+  def self.up
+    add_index :tags, :name, unique: true
+
+    remove_index :taggings, :tag_id
+    remove_index :taggings, [:taggable_id, :taggable_type, :context]
+    add_index :taggings,
+              [:tag_id, :taggable_id, :taggable_type, :context, :tagger_id, :tagger_type],
+              unique: true, name: 'taggings_idx'
+  end
+
+  def self.down
+    remove_index :tags, :name
+
+    remove_index :taggings, name: 'taggings_idx'
+    add_index :taggings, :tag_id
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+end

--- a/db/migrate/20160310061848_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20160310061848_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from acts_as_taggable_on_engine (originally 3)
+class AddTaggingsCounterCacheToTags < ActiveRecord::Migration
+  def self.up
+    add_column :tags, :taggings_count, :integer, default: 0
+
+    ActsAsTaggableOn::Tag.reset_column_information
+    ActsAsTaggableOn::Tag.find_each do |tag|
+      ActsAsTaggableOn::Tag.reset_counters(tag.id, :taggings)
+    end
+  end
+
+  def self.down
+    remove_column :tags, :taggings_count
+  end
+end

--- a/db/migrate/20160310061849_add_missing_taggable_index.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20160310061849_add_missing_taggable_index.acts_as_taggable_on_engine.rb
@@ -1,0 +1,10 @@
+# This migration comes from acts_as_taggable_on_engine (originally 4)
+class AddMissingTaggableIndex < ActiveRecord::Migration
+  def self.up
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+
+  def self.down
+    remove_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+end

--- a/db/migrate/20160310061850_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20160310061850_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
@@ -1,0 +1,10 @@
+# This migration comes from acts_as_taggable_on_engine (originally 5)
+# This migration is added to circumvent issue #623 and have special characters
+# work properly
+class ChangeCollationForTagNames < ActiveRecord::Migration
+  def up
+    if ActsAsTaggableOn::Utils.using_mysql?
+      execute("ALTER TABLE tags MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20151114002442) do
+ActiveRecord::Schema.define(:version => 20160310061850) do
 
   create_table "activity_logs", :force => true do |t|
     t.date     "start_date"
@@ -867,19 +867,22 @@ ActiveRecord::Schema.define(:version => 20151114002442) do
   create_table "taggings", :force => true do |t|
     t.integer  "tag_id"
     t.integer  "taggable_id"
+    t.string   "taggable_type"
     t.integer  "tagger_id"
     t.string   "tagger_type"
-    t.string   "taggable_type"
-    t.string   "context"
+    t.string   "context",       :limit => 128
     t.datetime "created_at"
   end
 
-  add_index "taggings", ["tag_id"], :name => "index_taggings_on_tag_id"
+  add_index "taggings", ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], :name => "taggings_idx", :unique => true
   add_index "taggings", ["taggable_id", "taggable_type", "context"], :name => "index_taggings_on_taggable_id_and_taggable_type_and_context"
 
   create_table "tags", :force => true do |t|
-    t.string "name"
+    t.string  "name"
+    t.integer "taggings_count", :default => 0
   end
+
+  add_index "tags", ["name"], :name => "index_tags_on_name", :unique => true
 
   create_table "terms", :force => true do |t|
     t.integer  "year"


### PR DESCRIPTION
Any model can be made taggable by adding `acts_as_taggable` in the
model. Then in a form, add a select box with class `taggable` to allow
tags to be added. By default the options are the collection value for
the select, but by adding `”data-tags” => true` to the input_html, it
will allow any arbitrary tag to be set.