### PR TITLE
Improve parent address export

### DIFF
--- a/app/assets/javascripts/reports.js
+++ b/app/assets/javascripts/reports.js
@@ -42,13 +42,13 @@ function refreshExportStatus(exportId, exportStatus, button_dom_id, status_dom_i
     break;
     
   case 'error':
-    button_elem.addClass("error").html("Download in Excel")
+    button_elem.addClass("error").html("Download " + exportReportTitle)
     status_elem.addClass("error").html("There was an error generating the file. Please try again.")
     updateFlashes({ "error": "There was an error generating your file. Please try again." })
     break;
     
   case 'expired':
-    button_elem.html("Download in Excel")
+    button_elem.html("Download " + exportReportTitle)
     status_elem.html("Export expired.")
     break;
     

--- a/app/assets/stylesheets/dreamsis.css.erb
+++ b/app/assets/stylesheets/dreamsis.css.erb
@@ -3021,6 +3021,11 @@ ul.big.choice li {
 	line-height: 20px;
 }
 
+td.phone {
+    padding-left: 0;
+    line-height: inherit;
+}
+
 .phone.home {
 	background: url(<%= asset_path 'icons/home_bw.gif' %>) center left no-repeat;
 }

--- a/app/models/people/parent.rb
+++ b/app/models/people/parent.rb
@@ -42,6 +42,38 @@ class Parent < Person
 		highest_education_level.try(:title)
 	end
   
+  def street
+    address_part_or_childs(:street)
+  end
+  
+  def city
+    address_part_or_childs(:city)
+  end
+  
+  def state
+    address_part_or_childs(:state)
+  end
+  
+  def zip
+    address_part_or_childs(:zip)
+  end
+  
+  # Returns the requested part of the address, but if the local value is blank,
+  # this method returns the child's equivalent address part. This allows us to
+  # share or export the parent's address if it's the same as the child's (which
+  # is common).
+  def address_part_or_childs(part)
+    raise Exception.new("Not a valid address part") unless %w[street city state zip].include?(part.to_s)
+    raw = read_attribute(part)
+    (raw.blank? || child_person.nil?) ? child_person.try(part) : raw
+  end
+  
+  # Returns true if the parent's address is blank and therefore assumed to be
+  # the same as the child's. For simplicity, we just check the +street+ attribute,
+  # and if it's blank we assume that we should use the child's address.
+  def address_is_same?
+    read_attribute(:street).blank?
+  end
   
   # Returns the preferred method of contact, ready for printing on the page.
   # For example, if the preferred contact method is "Home Phone", this method
@@ -62,7 +94,7 @@ class Parent < Person
     columns = [
       :id, :child_id, :child_lastname, :child_firstname, :formal_firstname, :middlename, :lastname, :suffix, 
       :parent_type, :lives_with,
-      :street, :city, :state, :zip, :email, :phone_home, :phone_mobile, :phone_work,
+      :street, :city, :state, :zip, :address_is_same?, :email, :phone_home, :phone_mobile, :phone_work,
       :other_languages, :occupation,	:annual_income,	:highest_education_level_title, :education_country,
       :meeting_availability, :needs_interpreter
     ]

--- a/app/views/parents/_parent.html.erb
+++ b/app/views/parents/_parent.html.erb
@@ -1,8 +1,28 @@
 <tr id="parent_<%= parent.id %>">
 
 	<td class="name"><%= link_to h(parent.fullname), [@participant, parent] %></td>
+
 	<td class="inline-when-small"><%=h parent.parent_type %></td>
-	<td class="inline-when-small"><%= auto_link h(parent.preferred_contact_detail) %></td>
+
+	<td class="lives_with">
+		<%= content_tag(:span, "Y", :class => "icon pass") if parent.lives_with? %>
+	</td>
+
+	<td class="email">
+	    <%= mail_to h(parent.email) %>
+		<%= content_tag(:div, "Preferred", :class => 'preferred-note') if parent.preferred_contact_method == 'Email' %>
+	</td>
+
+	<td class="phone">
+	    <% numbers = [] 
+			numbers << h(number_to_phone_pretty(parent.phone_home, :type => 'home')) unless parent.phone_home.blank?
+	     	numbers << h(number_to_phone_pretty(parent.phone_mobile, :type => 'mobile')) unless parent.phone_mobile.blank? %>
+		<%= numbers.join("<br />").html_safe %>
+	</td>
+
+	<td class="language">
+		<%= parent.other_languages %>
+	</td>
 	
 	<td class="functions">
 		<%= link_to 'Details', [@participant, parent] %>

--- a/app/views/participants/_export_actions.html.erb
+++ b/app/views/participants/_export_actions.html.erb
@@ -1,8 +1,9 @@
-<%= link_to "Download in Excel", xlsx_url, html_options = { :class => 'button xls with-below', :id => "export_download_button", :remote => true } %>
+<%= link_to "Download #{@export.try{ |e| e.class.to_s.titleize }}", xlsx_url, html_options = { :class => 'button xls with-below', :id => "export_download_button", :remote => true } %>
 
 <%= javascript_tag("checkExportStatus = false;") %>
 <%= javascript_tag("checkExportStatusUrl = '#{check_export_status_participants_url(:id => "__id__", :report => "__report__")}'") %>
 <%= javascript_tag("exportReportType = '#{params[:report]}'") %>
+<%= javascript_tag("exportReportTitle = '#{@export.try{ |e| e.class.to_s.titleize }}'") %>
 
 <p id="export_status" class="below">
 <%- if @export -%>	

--- a/app/views/participants/_parents.html.erb
+++ b/app/views/participants/_parents.html.erb
@@ -3,7 +3,10 @@
 		<tr>
 			<th>Name</th>
 			<th>Relationship</th>
-			<th>Preferred Contact</th>
+			<th>Lives With</th>
+			<th>E-mail</th>
+			<th>Phone</th>
+			<th>Language</th>
 			<th class="functions">Functions</th>
 		</tr>
 	</thead>

--- a/app/views/participants/index.js.erb
+++ b/app/views/participants/index.js.erb
@@ -3,6 +3,7 @@ if (<%=j @participants.current_page.to_s %> == 1) {
   $("#participants_table thead").html("<%=j render(:partial => 'participants/reports/table_header') %>")
   $("#export_actions").html("<%=j render('export_actions') %>")
   exportReportType = "<%=j @report %>"
+  exportReportTitle = "<%=j @export.try{ |e| e.class.to_s.titleize } %>"
 }
 
 // Append the new participant data to the table on the screen


### PR DESCRIPTION
Includes the child’s address if the parent’s is empty, and also makes it more obvious to the user that there are different types of export reports when viewing a participant list.