### PR TITLE
Restore MentorTermGroup Course ID selection UI

### DIFF
--- a/app/views/mentor_term_groups/_fields.html.erb
+++ b/app/views/mentor_term_groups/_fields.html.erb
@@ -25,7 +25,7 @@
 			section_ids = f.object.term.courses.collect(&:linked_section_ids).flatten rescue {}
 			section_ids = f.object.term.course_ids.split.to_a if section_ids.empty?
 		 %>
-		<!-- <%= f.input :course_id, :as => :select, :collection => section_ids, :hint => "Choose the course section that this group is attached to (if applicable)." %> -->
+		<%= f.input :course_id, :as => :select, :collection => section_ids, :hint => "Choose the course section that this group is attached to (if applicable)." %>
 		
 		<% 
 			linked_groups = {} # :title => :id


### PR DESCRIPTION
For some reason I commented this out in adf29fc7a3969023 but I can't fathom why.